### PR TITLE
Add ExtensionPreferences and WindowManager types

### DIFF
--- a/packages/gnome-shell/package.json
+++ b/packages/gnome-shell/package.json
@@ -26,6 +26,17 @@
       }
     },
     "./extensions/ambient": "./dist/extensions/index-ambient.d.ts",
+    "./extensions/prefs": {
+      "import": {
+        "types": "./dist/extensions/prefs.d.ts",
+        "default": "./dist/extensions/prefs.js"
+      },
+      "require": {
+        "types": "./dist/extensions/prefs.d.ts",
+        "default": "./dist/extensions/prefs.cjs"
+      }
+    },
+    "./extensions/prefs/ambient": "./dist/extensions/prefs-ambient.d.ts",
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
@@ -839,7 +850,18 @@
         "default": "./dist/ui/userWidget.cjs"
       }
     },
-    "./ui/userWidget/ambient": "./dist/ui/userWidget-ambient.d.ts"
+    "./ui/userWidget/ambient": "./dist/ui/userWidget-ambient.d.ts",
+    "./ui/windowManager": {
+      "import": {
+        "types": "./dist/ui/windowManager.d.ts",
+        "default": "./dist/ui/windowManager.js"
+      },
+      "require": {
+        "types": "./dist/ui/windowManager.d.ts",
+        "default": "./dist/ui/windowManager.cjs"
+      }
+    },
+    "./ui/windowManager/ambient": "./dist/ui/windowManager-ambient.d.ts"
   },
   "typedoc": {
     "entryPoint": "./src/index.d.ts",
@@ -861,6 +883,7 @@
   },
   "dependencies": {
     "@girs/accountsservice-1.0": "^1.0.0-3.2.5",
+    "@girs/adw-1": "^1.4.0-3.2.5",
     "@girs/atk-1.0": "^2.50.0-3.2.5",
     "@girs/cally-13": "^13.0.0-3.2.5",
     "@girs/clutter-13": "^13.0.0-3.2.5",

--- a/packages/gnome-shell/src/extensions/extension.d.ts
+++ b/packages/gnome-shell/src/extensions/extension.d.ts
@@ -4,7 +4,7 @@ import type { ExtensionBase, TranslationFunctions } from './sharedInternals.js';
 
 export class Extension extends ExtensionBase {
     static lookupByUUID(uuid: string): Extension | null;
-    static defineTranslationFunctions(url: string): void;
+    static defineTranslationFunctions(url: string): TranslationFunctions;
 
     /**
      * Open the extension's preferences window

--- a/packages/gnome-shell/src/extensions/prefs.d.ts
+++ b/packages/gnome-shell/src/extensions/prefs.d.ts
@@ -1,0 +1,32 @@
+import type Adw from '@girs/adw-1';
+
+import type { Extension } from './extension';
+import type { ExtensionBase, TranslationFunctions } from './sharedInternals';
+
+export class ExtensionPreferences extends ExtensionBase {
+  static lookupByUUID(uuid: string): Extension | null;
+  static defineTranslationFunctions(url: string): TranslationFunctions;
+
+  /**
+   * Get the single widget that implements
+   * the extension's preferences.
+   *
+   * @returns {Gtk.Widget}
+   * @throws {GObject.NotImplementedError}
+   */
+  getPreferencesWidget(): void;
+
+  /**
+   * Fill the preferences window with preferences.
+   *
+   * The default implementation adds the widget
+   * returned by getPreferencesWidget().
+   *
+   * @param {Adw.PreferencesWindow} window - the preferences window
+   */
+  fillPreferencesWindow(window: Adw.PreferencesWindow): void;
+}
+
+export declare const gettext: TranslationFunctions['gettext'];
+export declare const ngettext: TranslationFunctions['ngettext'];
+export declare const pgettext: TranslationFunctions['pgettext'];

--- a/packages/gnome-shell/src/ui/main.d.ts
+++ b/packages/gnome-shell/src/ui/main.d.ts
@@ -32,7 +32,7 @@ import { NotificationDaemon } from './notificationDaemon.js';
 // const SessionMode = imports.ui.sessionMode;
 // const ShellDBus = imports.ui.shellDBus;
 // const ShellMountOperation = imports.ui.shellMountOperation;
-// const WindowManager = imports.ui.windowManager;
+import { WindowManager } from './windowManager.js';
 // const Magnifier = imports.ui.magnifier;
 // const XdndHandler = imports.ui.xdndHandler;
 // const KbdA11yDialog = imports.ui.kbdA11yDialog;
@@ -69,6 +69,8 @@ export declare const shellAudioSelectionDBusService: any;
 export declare const screenSaverDBus: any;
 
 export declare const uiGroup: any;
+
+export declare const wm: WindowManager;
 
 export declare const magnifier: any;
 

--- a/packages/gnome-shell/src/ui/windowManager.d.ts
+++ b/packages/gnome-shell/src/ui/windowManager.d.ts
@@ -1,0 +1,28 @@
+import type Clutter from 'gi://Clutter';
+import type Gio from 'gi://Gio';
+import type Meta from 'gi://Meta';
+import type Shell from 'gi://Shell';
+
+export class WindowManager {
+    insertWorkspace(pos: number): void;
+
+    setCustomKeybindingHandler(
+        name: string,
+        modes: Shell.ActionMode,
+        handler: Meta.KeyHandlerFunc
+    ): void;
+
+    addKeybinding(
+        name: string,
+        settings: Gio.Settings,
+        flags: Meta.KeyBindingFlags,
+        modes: Shell.ActionMode,
+        handler: Meta.KeyHandlerFunc
+    ): number;
+
+    removeKeybinding(name: string): void;
+
+    allowKeybinding(name: string, modes: Shell.ActionMode): void;
+
+    handleWorkspaceScroll(event: Clutter.Event): boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,6 +171,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@girs/adw-1@npm:^1.4.0-3.2.5":
+  version: 1.4.0-3.2.5
+  resolution: "@girs/adw-1@npm:1.4.0-3.2.5"
+  dependencies:
+    "@girs/cairo-1.0": "npm:^1.0.0-3.2.5"
+    "@girs/freetype2-2.0": "npm:^2.0.0-3.2.5"
+    "@girs/gdk-4.0": "npm:^4.0.0-3.2.5"
+    "@girs/gdkpixbuf-2.0": "npm:^2.0.0-3.2.5"
+    "@girs/gio-2.0": "npm:^2.78.0-3.2.5"
+    "@girs/gjs": "npm:^3.2.5"
+    "@girs/glib-2.0": "npm:^2.78.0-3.2.5"
+    "@girs/gmodule-2.0": "npm:^2.0.0-3.2.5"
+    "@girs/gobject-2.0": "npm:^2.78.0-3.2.5"
+    "@girs/graphene-1.0": "npm:^1.0.0-3.2.5"
+    "@girs/gsk-4.0": "npm:^4.0.0-3.2.5"
+    "@girs/gtk-4.0": "npm:^4.12.3-3.2.5"
+    "@girs/harfbuzz-0.0": "npm:^8.2.1-3.2.5"
+    "@girs/pango-1.0": "npm:^1.51.0-3.2.5"
+    "@girs/pangocairo-1.0": "npm:^1.0.0-3.2.5"
+  checksum: 87f286d1d9d118442185a05a86c91cca96848047516a5a459e342547615c999ab65c193f07ef010c4a6b887da6bec2cf7a87dc8298e1c32383d6c81d1821f67e
+  languageName: node
+  linkType: hard
+
 "@girs/atk-1.0@npm:^2.50.0-3.2.5":
   version: 2.50.0-3.2.5
   resolution: "@girs/atk-1.0@npm:2.50.0-3.2.5"
@@ -434,6 +457,7 @@ __metadata:
   resolution: "@girs/gnome-shell@workspace:packages/gnome-shell"
   dependencies:
     "@girs/accountsservice-1.0": "npm:^1.0.0-3.2.5"
+    "@girs/adw-1": "npm:^1.4.0-3.2.5"
     "@girs/atk-1.0": "npm:^2.50.0-3.2.5"
     "@girs/cally-13": "npm:^13.0.0-3.2.5"
     "@girs/clutter-13": "npm:^13.0.0-3.2.5"


### PR DESCRIPTION
Thanks again for the updates you provided! I am only missing two exports:

```typescript
// The WindowManager is currently not available
import { WindowManager } from "resource:///org/gnome/shell/ui/windowManager.js";

// Also the ExtensionPreferences class is currently missing and invaluable when implementing a preferences dialog for Gnome extensions
import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
```
