### PR TITLE
Fix exported resource:// path for ExtensionPreferences

### DIFF
--- a/packages/gnome-shell/src/extensions/prefs.d.ts
+++ b/packages/gnome-shell/src/extensions/prefs.d.ts
@@ -1,30 +1,30 @@
 import type Adw from '@girs/adw-1';
 
-import type { Extension } from './extension';
-import type { ExtensionBase, TranslationFunctions } from './sharedInternals';
+import type { Extension } from './extension.js';
+import type { ExtensionBase, TranslationFunctions } from './sharedInternals.js';
 
 export class ExtensionPreferences extends ExtensionBase {
-  static lookupByUUID(uuid: string): Extension | null;
-  static defineTranslationFunctions(url: string): TranslationFunctions;
+    static lookupByUUID(uuid: string): Extension | null;
+    static defineTranslationFunctions(url: string): TranslationFunctions;
 
-  /**
-   * Get the single widget that implements
-   * the extension's preferences.
-   *
-   * @returns {Gtk.Widget}
-   * @throws {GObject.NotImplementedError}
-   */
-  getPreferencesWidget(): any; // TODO: Change this to Gtk.Widget as soon as this is implemented or extended
+    /**
+     * Get the single widget that implements
+     * the extension's preferences.
+     *
+     * @returns {Gtk.Widget}
+     * @throws {GObject.NotImplementedError}
+     */
+    getPreferencesWidget(): never;
 
-  /**
-   * Fill the preferences window with preferences.
-   *
-   * The default implementation adds the widget
-   * returned by getPreferencesWidget().
-   *
-   * @param {Adw.PreferencesWindow} window - the preferences window
-   */
-  fillPreferencesWindow(window: Adw.PreferencesWindow): void;
+    /**
+     * Fill the preferences window with preferences.
+     *
+     * The default implementation adds the widget
+     * returned by getPreferencesWidget().
+     *
+     * @param {Adw.PreferencesWindow} window - the preferences window
+     */
+    fillPreferencesWindow(window: Adw.PreferencesWindow): void;
 }
 
 export declare const gettext: TranslationFunctions['gettext'];

--- a/packages/gnome-shell/src/extensions/sharedInternals.d.ts
+++ b/packages/gnome-shell/src/extensions/sharedInternals.d.ts
@@ -64,7 +64,7 @@ export class ExtensionBase {
 
     get dir(): Gio.File
 
-    get path(): string 
+    get path(): string
 
     /**
      * Get a GSettings object for schema, using schema files in
@@ -75,7 +75,7 @@ export class ExtensionBase {
      *
      * @returns {}
      */
-    getSettings(schema: string): Gio.Settings
+    getSettings(schema?: string): Gio.Settings
 
     /**
      * Initialize Gettext to load translations from extensionsdir/locale. If


### PR DESCRIPTION
Hey @JumpLink , 

they new package you provided is great! I was able to boil down my type definitions file to basically this

`gnome-shell.d.ts`
```ts
/// <reference path="./node_modules/@girs/gjs/dom.d.ts" />
/// <reference path="./node_modules/@girs/gnome-shell/dist/index-ambient.d.ts" />
```

**Very nice!**

There are only two minor issues with the beta package that prevents me from using it currently. Both of which I address in this PR.

---

The first one is very minor: The `schema` argument passed to [ExtensionBase::getSettings](https://github.com/gjsify/gnome-shell/blob/main/packages/gnome-shell/src/extensions/sharedInternals.d.ts#L78) is **optional** (See [source code](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/8d7dc098b158be0a9f980fed97cad9031287e642/js/extensions/sharedInternals.js#L92) and [documentation](https://gjs.guide/extensions/overview/anatomy.html#settings-schema)).

---

The second one is a bit trickier: Depending on whether an import happens inside `extension.js` (or its recursive imports) or in `prefs.js` (or its recursive imports), the `resource://` prefix that must be used is different.  Note how the `ExtensionPreferences` type that I added in the previous PR must be imported in `prefs.js`:

```ts
import { ExtensionPreferences } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
// NOT:
import { ExtensionPreferences } from "resource:///org/gnome/shell/extensions/prefs.js";
```

Also see [the official documention](https://gjs.guide/extensions/upgrading/gnome-shell-45.html#esm) (yellow warning box).

Luckily the preference Dialog isn't supposed to import any other `resource://`'s other then the `ExtensionPreferences`. So I took the liberty to add a hardcoded condition that handles this specific case!

---

I also adapted the 4 space line indentation format and changed the exports from

```js
import * as ns from "@girs/gnome-shell${path}/${fileName}";
export = ns;
```

to 

```js
export * from "@girs/gnome-shell${path}/${fileName}";
```