### PR TITLE
Port some types to GNOME 46 + some additional types

### DIFF
--- a/packages/gnome-shell/package.json
+++ b/packages/gnome-shell/package.json
@@ -490,6 +490,17 @@
       }
     },
     "./ui/layout/ambient": "./dist/ui/layout-ambient.d.ts",
+    "./ui/lightbox": {
+      "import": {
+        "types": "./dist/ui/lightbox.d.ts",
+        "default": "./dist/ui/lightbox.js"
+      },
+      "require": {
+        "types": "./dist/ui/lightbox.d.ts",
+        "default": "./dist/ui/lightbox.cjs"
+      }
+    },
+    "./ui/lightbox/ambient": "./dist/ui/lightbox-ambient.d.ts",
     "./ui/main": {
       "import": {
         "types": "./dist/ui/main.d.ts",

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -32,12 +32,17 @@ export class Dialog extends St.Widget {
     protected _setInitialKeyFocus(actor: St.Widget): void;
 }
 
+export interface MessageDialogContentProps extends St.BoxLayout.ConstructorProperties{
+    title?: string;
+    description?: string;
+}
+
 export class MessageDialogContent extends St.BoxLayout {
     public title: string;
     public description: string;
 
-    constructor(params: St.BoxLayout.ConstructorProperties);
-    public _init(params: St.BoxLayout.ConstructorProperties): void;
+    constructor(params: MessageDialogContentProps);
+    public _init(params: MessageDialogContentProps): void;
 
     protected _onDestroy(): void;
     protected _updateTitleStyle(): void;

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -11,6 +11,9 @@ export interface ButtonInfo {
     default?: boolean;
 }
 
+/**
+ * @version 46
+ */
 export class Dialog extends St.Widget {
 
     protected _parentActor: St.Widget;
@@ -32,11 +35,14 @@ export class Dialog extends St.Widget {
     protected _setInitialKeyFocus(actor: St.Widget): void;
 }
 
-export interface MessageDialogContentProps extends St.BoxLayout.ConstructorProperties{
+export interface MessageDialogContentProps extends St.BoxLayout.ConstructorProperties {
     title?: string;
     description?: string;
 }
 
+/**
+ * @version 46
+ */
 export class MessageDialogContent extends St.BoxLayout {
     public title: string;
     public description: string;
@@ -45,9 +51,16 @@ export class MessageDialogContent extends St.BoxLayout {
     public _init(params: MessageDialogContentProps): void;
 
     protected _onDestroy(): void;
-    protected _updateTitleStyle(): void;
+    protected _updateTitleStyle(): void | false;
 }
 
+export interface ListSectionProps extends St.BoxLayout.ConstructorProperties {
+    title?: string;
+}
+
+/**
+ * @version 46
+ */
 export class ListSection extends St.BoxLayout {
 
     protected _listScrollView: St.ScrollView;
@@ -57,10 +70,19 @@ export class ListSection extends St.BoxLayout {
     public title: string;
     public label_actor: St.Label;
 
-    constructor(params: St.BoxLayout.ConstructorProperties);
-    public _init(params: St.BoxLayout.ConstructorProperties): void;
+    constructor(params: ListSectionProps);
+    public _init(params: ListSectionProps): void;
 }
 
+export interface ListSectionItemProps extends St.BoxLayout.ConstructorProperties {
+    title?: string;
+    description?: string;
+    // note: iconActor hasn't: GObject.ParamFlags.CONSTRUCT, but might work anyways?
+}
+
+/**
+ * @version 46
+ */
 export class ListSectionItem extends St.BoxLayout {
 
     protected _iconActorBin: St.Bin;
@@ -72,6 +94,6 @@ export class ListSectionItem extends St.BoxLayout {
 
     constructor(params: { style_class?: string | null });
     /** @hidden Defined to resolve version conflicts */
-    public _init(config?: St.BoxLayout.ConstructorProperties): void;
+    public _init(config?: ListSectionItemProps): void;
     public _init(params: { style_class?: string | null }): void;
 }

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -15,7 +15,6 @@ export interface ButtonInfo {
  * @version 46
  */
 export class Dialog extends St.Widget {
-
     protected _parentActor: St.Widget;
     protected _dialog: St.BoxLayout;
     protected _initialKeyFocus: St.Widget;
@@ -35,11 +34,15 @@ export class Dialog extends St.Widget {
     protected _setInitialKeyFocus(actor: St.Widget): void;
 }
 
-export interface MessageDialogContentProps extends St.BoxLayout.ConstructorProperties {
-    title?: string;
-    description?: string;
+/**
+ * @version 46
+ */
+export namespace MessageDialogContent {
+    export interface ConstructorProperties extends St.BoxLayout.ConstructorProperties {
+        title?: string;
+        description?: string;
+    }
 }
-
 /**
  * @version 46
  */
@@ -47,8 +50,8 @@ export class MessageDialogContent extends St.BoxLayout {
     public title: string;
     public description: string;
 
-    constructor(params: MessageDialogContentProps);
-    public _init(params: MessageDialogContentProps): void;
+    constructor(params: MessageDialogContent.ConstructorProperties);
+    public _init(params: MessageDialogContent.ConstructorProperties): void;
 
     protected _onDestroy(): void;
     protected _updateTitleStyle(): void | false;
@@ -62,7 +65,6 @@ export interface ListSectionProps extends St.BoxLayout.ConstructorProperties {
  * @version 46
  */
 export class ListSection extends St.BoxLayout {
-
     protected _listScrollView: St.ScrollView;
     protected _title: St.Label;
 
@@ -84,7 +86,6 @@ export interface ListSectionItemProps extends St.BoxLayout.ConstructorProperties
  * @version 46
  */
 export class ListSectionItem extends St.BoxLayout {
-
     protected _iconActorBin: St.Bin;
     protected _title: St.Label;
 

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -24,7 +24,7 @@ export class Dialog extends St.Widget {
     public _init(parentActor: St.Widget, styleClass?: string | null): void;
     public makeInactive(): void;
     public vfunc_event(event: Clutter.Event): boolean;
-    public addButton(buttonInfo: ButtonInfo): void;
+    public addButton(buttonInfo: ButtonInfo): St.Button;
     public clearButtons(): void;
 
     protected _createDialog(): void;

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -20,18 +20,22 @@ export interface Geometry {
     width: number;
     height: number;
 }
+/**
+ * @version 46
+ */
 
-export interface MonitorConstraintProps extends Clutter.Constraint.ConstructorProperties {
-    primary?: boolean;
-    index?: number;
-    workArea?: boolean;
+export namespace MonitorConstraint {
+    export interface ConstructorProperties extends Clutter.Constraint.ConstructorProperties {
+        primary?: boolean;
+        index?: number;
+        workArea?: boolean;
+    }
 }
 
 /**
  * @version 46
  */
 export class MonitorConstraint extends Clutter.Constraint {
-
     protected _primary: boolean;
     protected _index: number;
     protected _workArea: boolean;
@@ -40,19 +44,17 @@ export class MonitorConstraint extends Clutter.Constraint {
     public index: number;
     public workArea: boolean;
 
-    constructor(props: MonitorConstraintProps);
-    public _init(props: MonitorConstraintProps): void;
+    constructor(props: MonitorConstraint.ConstructorProperties);
+    public _init(props: MonitorConstraint.ConstructorProperties): void;
 
     public vfunc_set_actor(actor: Clutter.Actor): void;
     public vfunc_update_allocation(actor: Clutter.Actor, actorBox: Clutter.ActorBox): void;
 }
 
-
 /**
  * @version 46
  */
 declare class Monitor {
-
     public index: number;
     public geometryScale: number;
     public x: number;
@@ -90,7 +92,6 @@ declare class ScreenTransition extends Clutter.Actor {
  * overview.
  */
 declare class HotCorner extends Clutter.Actor {
-
     protected _entered: boolean;
     protected _monitor: Monitor;
     protected _x: number;
@@ -114,13 +115,16 @@ declare class HotCorner extends Clutter.Actor {
 }
 
 export class LayoutManager extends GObject.Object {
-
     protected _rtl: boolean;
     protected _keyboardIndex: number;
     protected _rightPanelBarrier: Meta.Barrier | null;
     protected _inOverview: boolean;
     protected _updateRegionIdle: number;
-    protected _trackedActors: { trackFullscreen: boolean; affectsStruts: boolean; affectsInputRegion: boolean; }[];
+    protected _trackedActors: {
+        trackFullscreen: boolean;
+        affectsStruts: boolean;
+        affectsInputRegion: boolean;
+    }[];
     protected _keyboardHeightNotifyId: number;
     protected _backgroundGroup: Meta.BackgroundGroup;
     protected _interfaceSettings: Gio.Settings;
@@ -165,12 +169,12 @@ export class LayoutManager extends GObject.Object {
      * function before you show the menu to ensure it is at the right
      * position and has the right size.
      * @param x
-     * @param y 
-     * @param width 
-     * @param height 
+     * @param y
+     * @param width
+     * @param height
      */
     public setDummyCursorGeometry(x: number, y: number, width: number, height: number): void;
-    
+
     /**
      * Adds `actor` to the chrome, and (unless `affectsInputRegion` in
      * `params` is `false`) extends the input region to include it.
@@ -190,27 +194,48 @@ export class LayoutManager extends GObject.Object {
      * @param actor An actor to add to the chrome
      * @param params Additional params
      */
-    public addChrome(actor: Clutter.Actor, params?: { affectsStruts?: boolean; affectsInputRegion?: boolean; trackFullscreen?: boolean; }): void;
+    public addChrome(
+        actor: Clutter.Actor,
+        params?: {
+            affectsStruts?: boolean;
+            affectsInputRegion?: boolean;
+            trackFullscreen?: boolean;
+        }
+    ): void;
 
     /**
      * Like {@link addChrome()}, but adds `actor` above all windows, including popups.
      * @param actor An actor to add to the chrome
      * @param params Additional params
      */
-    public addTopChrome(actor: Clutter.Actor, params?: { affectsStruts?: boolean; affectsInputRegion?: boolean; trackFullscreen?: boolean; }): void;
-    
+    public addTopChrome(
+        actor: Clutter.Actor,
+        params?: {
+            affectsStruts?: boolean;
+            affectsInputRegion?: boolean;
+            trackFullscreen?: boolean;
+        }
+    ): void;
+
     /**
      * Tells the chrome to track `actor`. This can be used to extend the
      * struts or input region to cover specific children.
-     * 
+     *
      * `params` can have any of the same values as in {@link addChrome()},
      * though some possibilities don't make sense. By default, `actor` has
      * the same params as its chrome ancestor.
-     * 
+     *
      * @param actor a descendant of the chrome to begin tracking
      * @param params parameters describing how to track `actor`
      */
-    public trackChrome(actor: Clutter.Actor, params?: { affectsStruts?: boolean; affectsInputRegion?: boolean; trackFullscreen?: boolean; }): void;
+    public trackChrome(
+        actor: Clutter.Actor,
+        params?: {
+            affectsStruts?: boolean;
+            affectsInputRegion?: boolean;
+            trackFullscreen?: boolean;
+        }
+    ): void;
 
     /**
      * Undoes the effect of {@link trackChrome()}
@@ -230,14 +255,13 @@ export class LayoutManager extends GObject.Object {
     /**
      * This call guarantees that we return some monitor to simplify usage of it
      * In practice all tracked actors should be visible on some monitor anyway
-     * @param actor 
+     * @param actor
      */
-    public findIndexForActor(actor: Clutter.Actor): number
+    public findIndexForActor(actor: Clutter.Actor): number;
 
-    public findMonitorForActor(actor: Clutter.Actor): Monitor | undefined
+    public findMonitorForActor(actor: Clutter.Actor): Monitor | undefined;
 
     public modalEnded(): void;
-
 
     protected _sessionUpdated(): void;
     protected _updateMonitors(): void;
@@ -276,7 +300,14 @@ export class LayoutManager extends GObject.Object {
     protected _startupAnimationSession(): void;
     protected _startupAnimationComplete(): void;
     protected _findActor(actor: Clutter.Actor): number;
-    protected _trackActor(actor: Clutter.Actor, params?: { affectsStruts?: boolean; affectsInputRegion?: boolean; trackFullscreen?: boolean; }): void;
+    protected _trackActor(
+        actor: Clutter.Actor,
+        params?: {
+            affectsStruts?: boolean;
+            affectsInputRegion?: boolean;
+            trackFullscreen?: boolean;
+        }
+    ): void;
     protected _untrackActor(actor: Clutter.Actor): void;
     protected _updateActorVisibility(actorData: any): void;
     protected _updateVisibility(): void;
@@ -287,7 +318,6 @@ export class LayoutManager extends GObject.Object {
 }
 
 declare class PressureBarrier extends EventEmitter {
-
     protected _threshold: number;
     protected _timeout: number;
     protected _actionMode: number;
@@ -315,4 +345,3 @@ declare class PressureBarrier extends EventEmitter {
     protected _trigger(): void;
     protected _onBarrierHit(barrier: Meta.Barrier, event: any): void;
 }
-

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -21,6 +21,13 @@ export interface Geometry {
     height: number;
 }
 
+export interface MonitorConstraintProps extends Clutter.Constraint.ConstructorProperties {
+    primary?: boolean;
+    index?: number;
+    workArea?: boolean;
+}
+
+
 export class MonitorConstraint extends Clutter.Constraint {
 
     protected _primary: boolean;
@@ -31,8 +38,8 @@ export class MonitorConstraint extends Clutter.Constraint {
     public index: number;
     public workArea: boolean;
 
-    constructor(props: Clutter.Constraint.ConstructorProperties);
-    public _init(props: Clutter.Constraint.ConstructorProperties): void;
+    constructor(props: MonitorConstraintProps);
+    public _init(props: MonitorConstraintProps): void;
 
     public vfunc_update_allocation(actor: Clutter.Actor, actorBox: Clutter.ActorBox): void;
 }

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -27,7 +27,9 @@ export interface MonitorConstraintProps extends Clutter.Constraint.ConstructorPr
     workArea?: boolean;
 }
 
-
+/**
+ * @version 46
+ */
 export class MonitorConstraint extends Clutter.Constraint {
 
     protected _primary: boolean;
@@ -41,9 +43,14 @@ export class MonitorConstraint extends Clutter.Constraint {
     constructor(props: MonitorConstraintProps);
     public _init(props: MonitorConstraintProps): void;
 
+    public vfunc_set_actor(actor: Clutter.Actor): void;
     public vfunc_update_allocation(actor: Clutter.Actor, actorBox: Clutter.ActorBox): void;
 }
 
+
+/**
+ * @version 46
+ */
 declare class Monitor {
 
     public index: number;
@@ -57,6 +64,9 @@ declare class Monitor {
     constructor(index: number, geometry: Geometry, geometryScale: number);
 }
 
+/**
+ * @version 46
+ */
 declare class UiActor extends St.Widget {
     public constructor(props?: St.Widget.ConstructorProperties);
     public _init(props?: St.Widget.ConstructorProperties): void;

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -1,0 +1,58 @@
+// https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js
+
+import type Clutter from "@girs/clutter-14"
+import type St from "@girs/st-14"
+import type Shell from "@girs/shell-14"
+
+export const DEFAULT_FADE_FACTOR = 0.4
+export const VIGNETTE_BRIGHTNESS = 0.5
+export const VIGNETTE_SHARPNESS = 0.7
+
+export interface RadialShaderEffectProps
+    extends Shell.GLSLEffect.ConstructorProperties {
+    brightness?: number
+    sharpness?: number
+}
+
+export class RadialShaderEffect extends Shell.GLSLEffect {
+    protected _brightness: number
+    protected _sharpness: number
+
+    public brightness: number
+    public sharpness: number
+
+    constructor(props: RadialShaderEffectProps)
+    public _init(props: RadialShaderEffectProps): void
+
+    vfunc_build_pipeline(): void
+}
+
+export interface LightboxAdditionalParameters {
+    inhibitEvents?: boolean
+    width?: number
+    height?: number
+    fadeFactor?: number
+    radialEffect?: boolean
+}
+
+export interface LightboxProps
+    extends St.Bin.ConstructorProperties,
+        LightboxAdditionalParameters {
+    brightness?: number
+    sharpness?: number
+}
+
+export class Lightbox extends St.Bin {
+    protected _active: boolean
+
+    public readonly active: boolean
+
+    constructor(container: Clutter.Actor, params?: LightboxProps)
+    public _init(container: Clutter.Actor, params?: LightboxProps): void
+
+    lightOn(fadeInTime?: number): void
+
+    lightOff(fadeOutTime?: number): void
+
+    highlight(window: Clutter.Actor): void
+}

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -14,6 +14,9 @@ export interface RadialShaderEffectProps
     sharpness?: number
 }
 
+/**
+ * @version 46
+ */
 export class RadialShaderEffect extends Shell.GLSLEffect {
     protected _brightness: number
     protected _sharpness: number
@@ -42,17 +45,47 @@ export interface LightboxProps
     sharpness?: number
 }
 
+/**
+ * @version 46
+ */
 export class Lightbox extends St.Bin {
     protected _active: boolean
 
     public readonly active: boolean
 
+    /**
+     * Lightbox creates a dark translucent "shade" actor to hide the
+     * contents of `container`, and allows you to specify particular actors
+     * in `container` to highlight by bringing them above the shade. It
+     * tracks added and removed actors in `container` while the lightboxing
+     * is active, and ensures that all actors are returned to their
+     * original stacking order when the lightboxing is removed. (However,
+     * if actors are restacked by outside code while the lightboxing is
+     * active, the lightbox may later revert them back to their original
+     * order.)
+     *
+     * By default, the shade window will have the height and width of
+     * `container` and will track any changes in its size. You can override
+     * this by passing an explicit width and height in `params`.
+     *
+     * @param {Clutter.Container} container parent Clutter.Container
+     * @param {object} [params] additional parameters:
+     * @param {boolean=} params.inhibitEvents: whether to inhibit events for `container`
+     * @param {number=} params.width: shade actor width
+     * @param {number=} params.height: shade actor height
+     * @param {number=} params.fadeFactor: fading opacity factor
+     * @param {boolean=} params.radialEffect: whether to enable the GLSL radial effect
+     */
     constructor(container: Clutter.Actor, params?: LightboxProps)
     public _init(container: Clutter.Actor, params?: LightboxProps): void
 
     lightOn(fadeInTime?: number): void
-
     lightOff(fadeOutTime?: number): void
 
     highlight(window: Clutter.Actor): void
+
+    protected _childAdded(container: Clutter.Actor, newChild: Clutter.Actor): void;
+    protected _childRemoved(container: Clutter.Actor, child: Clutter.Actor): void;
+    protected _onDestroy(): void;
+
 }

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -1,57 +1,64 @@
 // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js
 
-import type Clutter from "@girs/clutter-14"
-import type St from "@girs/st-14"
-import type Shell from "@girs/shell-14"
+import type Clutter from '@girs/clutter-14';
+import type St from '@girs/st-14';
+import type Shell from '@girs/shell-14';
 
-export const DEFAULT_FADE_FACTOR = 0.4
-export const VIGNETTE_BRIGHTNESS = 0.5
-export const VIGNETTE_SHARPNESS = 0.7
+export const DEFAULT_FADE_FACTOR = 0.4;
+export const VIGNETTE_BRIGHTNESS = 0.5;
+export const VIGNETTE_SHARPNESS = 0.7;
 
-export interface RadialShaderEffectProps
-    extends Shell.GLSLEffect.ConstructorProperties {
-    brightness?: number
-    sharpness?: number
+/**
+ * @version 46
+ */
+export namespace RadialShaderEffect {
+    export interface ConstructorProperties extends Shell.GLSLEffect.ConstructorProperties {
+        brightness?: number;
+        sharpness?: number;
+    }
 }
 
 /**
  * @version 46
  */
 export class RadialShaderEffect extends Shell.GLSLEffect {
-    protected _brightness: number
-    protected _sharpness: number
+    protected _brightness: number;
+    protected _sharpness: number;
 
-    public brightness: number
-    public sharpness: number
+    public brightness: number;
+    public sharpness: number;
 
-    constructor(props: RadialShaderEffectProps)
-    public _init(props: RadialShaderEffectProps): void
+    constructor(props: RadialShaderEffect.ConstructorProperties);
+    public _init(props: RadialShaderEffect.ConstructorProperties): void;
 
-    vfunc_build_pipeline(): void
+    vfunc_build_pipeline(): void;
 }
 
 export interface LightboxAdditionalParameters {
-    inhibitEvents?: boolean
-    width?: number
-    height?: number
-    fadeFactor?: number
-    radialEffect?: boolean
+    inhibitEvents?: boolean;
+    width?: number;
+    height?: number;
+    fadeFactor?: number;
+    radialEffect?: boolean;
 }
 
-export interface LightboxProps
-    extends St.Bin.ConstructorProperties,
-        LightboxAdditionalParameters {
-    brightness?: number
-    sharpness?: number
+/**
+ * @version 46
+ */
+export namespace Lightbox {
+    export interface ConstructorProperties extends St.Bin.ConstructorProperties, LightboxAdditionalParameters {
+        brightness?: number;
+        sharpness?: number;
+    }
 }
 
 /**
  * @version 46
  */
 export class Lightbox extends St.Bin {
-    protected _active: boolean
+    protected _active: boolean;
 
-    public readonly active: boolean
+    public readonly active: boolean;
 
     /**
      * Lightbox creates a dark translucent "shade" actor to hide the
@@ -76,16 +83,15 @@ export class Lightbox extends St.Bin {
      * @param {number=} params.fadeFactor: fading opacity factor
      * @param {boolean=} params.radialEffect: whether to enable the GLSL radial effect
      */
-    constructor(container: Clutter.Actor, params?: LightboxProps)
-    public _init(container: Clutter.Actor, params?: LightboxProps): void
+    constructor(container: Clutter.Actor, params?: Lightbox.ConstructorProperties);
+    public _init(container: Clutter.Actor, params?: Lightbox.ConstructorProperties): void;
 
-    lightOn(fadeInTime?: number): void
-    lightOff(fadeOutTime?: number): void
+    lightOn(fadeInTime?: number): void;
+    lightOff(fadeOutTime?: number): void;
 
-    highlight(window: Clutter.Actor): void
+    highlight(window: Clutter.Actor): void;
 
     protected _childAdded(container: Clutter.Actor, newChild: Clutter.Actor): void;
     protected _childRemoved(container: Clutter.Actor, child: Clutter.Actor): void;
     protected _onDestroy(): void;
-
 }

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -4,7 +4,7 @@ import type St from '@girs/st-14';
 import type Shell from '@girs/shell-14';
 
 import type { MonitorConstraint } from './layout.js';
-import type { Dialog } from './dialog.js';
+import type { ButtonInfo, Dialog } from './dialog.js';
 
 export enum State {
     OPENED = 0,
@@ -71,8 +71,8 @@ export class ModalDialog extends St.Widget {
     protected _fadeOutDialog(timestamp: number): void;
 
     public clearButtons(): void;
-    public setButtons(buttons: any[]): void;
-    public addButton(buttonInfo: any): void;
+    public setButtons(buttons: ButtonInfo[]): void;
+    public addButton(buttonInfo: ButtonInfo): St.Button;
     public setInitialKeyFocus(actor: St.Widget): void;
     public open(): boolean;
     public close(): boolean;

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -67,7 +67,6 @@ export class ModalDialog extends St.Widget {
      * e.g., if a user clicked "Log Out" then the dialog should go away
      * immediately, but the lightbox should remain until the logout is
      * complete.
-     * @param timestamp 
      */
     protected _fadeOutDialog(timestamp: number): void;
 
@@ -75,14 +74,14 @@ export class ModalDialog extends St.Widget {
     public setButtons(buttons: any[]): void;
     public addButton(buttonInfo: any): void;
     public setInitialKeyFocus(actor: St.Widget): void;
-    public open(timestamp: number, onPrimary: boolean): boolean;
-    public close(timestamp: number): boolean;
+    public open(): boolean;
+    public close(): boolean;
     /**
      * Drop modal status without closing the dialog; this makes the
      * dialog insensitive as well, so it needs to be followed shortly
      * by either a close() or a pushModal()
      * @param timestamp 
      */
-    public popModal(timestamp: number): void;
-    public pushModal(timestamp: number): void;
+    public popModal(): void;
+    public pushModal(): void;
 }

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -2,10 +2,14 @@
 
 import type St from '@girs/st-14';
 import type Shell from '@girs/shell-14';
+import type Clutter from '@girs/clutter-14';
 
 import type { MonitorConstraint } from './layout.js';
 import type { ButtonInfo, Dialog } from './dialog.js';
 
+/**
+ * @version 46
+ */
 export enum State {
     OPENED = 0,
     CLOSED = 1,
@@ -14,6 +18,9 @@ export enum State {
     FADED_OUT = 4,
 }
 
+/**
+ * @version 46
+ */
 export namespace ModalDialog {
     export interface ConstructorProperties {
         shellReactive?: boolean;
@@ -25,6 +32,9 @@ export namespace ModalDialog {
     }
 }
 
+/**
+ * @version 46
+ */
 export class ModalDialog extends St.Widget {
 
     protected _state: State;
@@ -70,17 +80,20 @@ export class ModalDialog extends St.Widget {
      */
     protected _fadeOutDialog(timestamp: number): void;
 
+    public vfunc_key_press_event(event: Clutter.Event): boolean;
+    public vfunc_captured_event(event: Clutter.Event): boolean;
+
     public clearButtons(): void;
     public setButtons(buttons: ButtonInfo[]): void;
     public addButton(buttonInfo: ButtonInfo): St.Button;
     public setInitialKeyFocus(actor: St.Widget): void;
     public open(): boolean;
+    //note: upstream has timestamp as paramater here, but it only will be used to call popModal, which doesn't accept that paramater anymore, so this is just a bug upstream
     public close(): boolean;
     /**
      * Drop modal status without closing the dialog; this makes the
      * dialog insensitive as well, so it needs to be followed shortly
      * by either a close() or a pushModal()
-     * @param timestamp 
      */
     public popModal(): void;
     public pushModal(): void;

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -22,7 +22,7 @@ export enum State {
  * @version 46
  */
 export namespace ModalDialog {
-    export interface ConstructorProperties {
+    export interface ConstructorProperties extends St.Widget.ConstructorProperties {
         shellReactive?: boolean;
         styleClass?: string | null;
         actionMode?: Shell.ActionMode;
@@ -36,7 +36,6 @@ export namespace ModalDialog {
  * @version 46
  */
 export class ModalDialog extends St.Widget {
-
     protected _state: State;
     protected _hasModal: boolean;
     protected _actionMode: Shell.ActionMode;
@@ -56,10 +55,8 @@ export class ModalDialog extends St.Widget {
     public buttonLayout: Dialog['buttonLayout'];
     public state: State;
 
-    constructor(params?: ModalDialog.ConstructorProperties)
+    constructor(params?: ModalDialog.ConstructorProperties);
 
-    /** @hidden */
-    public _init(params?: St.Widget.ConstructorProperties): void;
     public _init(params?: ModalDialog.ConstructorProperties): void;
 
     protected _setState(state: State): void;


### PR DESCRIPTION
This ports some types to GNOME 46 and adds a new file: 
[ui/lightbox](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js)

This fixes only types, I need for an extension, and some things that changed, that I saw while doing that.
