### PR TITLE
Update dateMenu for GNOME 46

### DIFF
--- a/packages/gnome-shell/src/ui/dateMenu.d.ts
+++ b/packages/gnome-shell/src/ui/dateMenu.d.ts
@@ -1,29 +1,9 @@
 // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dateMenu.js
 
-import type Clutter from "@girs/clutter-14";
-import type St from "@girs/st-14";
 
-import type { EventSourceBase } from "./calendar.js";
 import type { Button } from "./panelMenu.js";
 
-export class TodayButton extends St.Button {
-    setDate(date: Date): void;
-}
-
-export class EventsSection extends St.Button {
-    setDate(date: Date): void;
-
-    setEventSource(eventSource: EventSourceBase): void;
-}
-
-export class WordClocksSection extends St.Button {}
-
-export class WeatherSection extends St.Button {}
-
-export class MessagesIndicator extends St.Icon {}
-
-export class FreezableBinLayout extends Clutter.BinLayout {}
-
-export class CalendarColumnLayout extends Clutter.BoxLayout {}
-
+/**
+ * @version 46
+ */
 export class DateMenuButton extends Button {}


### PR DESCRIPTION
Mark DateMenuButton for GNOME 46, and remove all other types which are not exported anymore in GNOME 46.
