### PR TITLE
Remove redundant width and height

### DIFF
--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -36,8 +36,6 @@ export class RadialShaderEffect extends Shell.GLSLEffect {
 
 export interface LightboxAdditionalParameters {
     inhibitEvents?: boolean;
-    width?: number;
-    height?: number;
     fadeFactor?: number;
     radialEffect?: boolean;
 }

--- a/packages/gnome-shell/tsconfig.json
+++ b/packages/gnome-shell/tsconfig.json
@@ -1,13 +1,18 @@
 {
-  "compilerOptions": {   
-    "lib": ["ESNext"],
-    "types": [],
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-  },
-  "include": ["./dist/**/*.d.ts"],
-  "files": [
-    "./dist/index.d.ts",
-  ],
+    "compilerOptions": {
+        "lib": ["ESNext"],
+        "types": [],
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "noImplicitAny": true,
+        "strictNullChecks": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "strictPropertyInitialization": true,
+        "allowSyntheticDefaultImports": true
+    },
+    "include": ["./dist/**/*.d.ts"],
+    "files": ["./dist/index.d.ts"]
 }


### PR DESCRIPTION
These are already declared by Clutter.Actor, and our declarations are conflicting because they omit null.

Fixes the following compiler errors:

```
node_modules/.pnpm/@girs+gnome-shell@46.0.0-beta4/node_modules/@girs/gnome-shell/dist/ui/lightbox.d.ts:49:22 - error TS2320: Interface 'ConstructorProperties' cannot simultaneously extend types 'ConstructorProperties' and 'LightboxAdditionalParameters'.
  Named property 'height' of types 'ConstructorProperties' and 'LightboxAdditionalParameters' are not identical.

49     export interface ConstructorProperties extends St.Bin.ConstructorProperties, LightboxAdditionalParameters {
                        ~~~~~~~~~~~~~~~~~~~~~

node_modules/.pnpm/@girs+gnome-shell@46.0.0-beta4/node_modules/@girs/gnome-shell/dist/ui/lightbox.d.ts:49:22 - error TS2320: Interface 'ConstructorProperties' cannot simultaneously extend types 'ConstructorProperties' and 'LightboxAdditionalParameters'.
  Named property 'width' of types 'ConstructorProperties' and 'LightboxAdditionalParameters' are not identical.

49     export interface ConstructorProperties extends St.Bin.ConstructorProperties, LightboxAdditionalParameters {
                        ~~~~~~~~~~~~~~~~~~~~~


Found 2 errors.
```
