### PR TITLE
Add missing `actor` member on `PopupMenu`

### DIFF
--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -205,7 +205,8 @@ export class PopupMenu<S extends Signals.SignalMap<S> = PopupMenu.SignalMap> ext
  */
 export class PopupDummyMenu extends Signals.EventEmitter {
     constructor(sourceActor: St.Widget);
-
+    
+    readonly actor: St.Widget;
     readonly sensitive: boolean;
 
     getSensitive(): boolean;
@@ -250,6 +251,8 @@ export namespace PopupMenuSection {
  */
 export class PopupMenuSection<S extends Signals.SignalMap<S> = PopupMenuSection.SignalMap> extends PopupMenuBase<S> {
     constructor();
+
+    readonly actor: St.BoxLayout;
 
     open(): void;
     close(): void;

--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -7,6 +7,7 @@ import type Clutter from '@girs/clutter-14';
 import type Meta from '@girs/meta-14';
 
 import * as Signals from '../misc/signals.js';
+import * as BoxPointer from './boxpointer.js';
 
 /**
  * @version 46
@@ -190,6 +191,7 @@ export namespace PopupMenu {
  */
 export class PopupMenu<S extends Signals.SignalMap<S> = PopupMenu.SignalMap> extends PopupMenuBase<S> {
     constructor(sourceActor: St.Widget, arrowAlignment: number, arrowSide: St.Side);
+    readonly actor: BoxPointer.BoxPointer;
 
     setArrowOrigin(origin: number): void;
     setSourceAlignment(alignment: number): void;

--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -205,7 +205,7 @@ export class PopupMenu<S extends Signals.SignalMap<S> = PopupMenu.SignalMap> ext
  */
 export class PopupDummyMenu extends Signals.EventEmitter {
     constructor(sourceActor: St.Widget);
-    
+
     readonly actor: St.Widget;
     readonly sensitive: boolean;
 


### PR DESCRIPTION
The `PopupMenu` class has an `actor` member of type `BoxPointer` that's used when setting up a menu for a panel indicator. It's defined here: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js?#L879

An example of this member being accessed from outside the class can be found here: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/gdm/loginDialog.js#L337

When implementing a menu for an indicator, you would do something like this:
```ts
class MyIndicatorMenu extends PopupMenu.PopupMenu {
  constructor(sourceActor: St.Widget, arrowAlignment: number, arrowSide: St.Side) {
    super(sourceActor, arrowAlignment, arrowSide);

    Main.uiGroup.add_child(this.actor);
    this.actor.hide();

    this.addAction("Some action", () => { });
  }
}
```
Without this addition you have to resort to `(this as any).actor` in order to add the menu to `uiGroup` and hide it appropriately without type errors.

From the shell code, it doesn't seem like it's ever modified from the outside, so I've made it `readonly`.

EDIT: I've added the missing `actor` member to `PopupDummyMenu` and `PopupMenuSection` as well.