### PR TITLE
Beta fixes: Optional Properties handling

### DIFF
--- a/packages/gnome-shell/src/ui/animation.d.ts
+++ b/packages/gnome-shell/src/ui/animation.d.ts
@@ -8,7 +8,7 @@ export class Animation extends St.Bin {
     constructor(file: Gio.File, width: number, height: number, speed: number);
 
     /** @hidden */
-    public _init(props?: St.Bin.ConstructorProps): void;
+    public _init(props?: Partial<St.Bin.ConstructorProps>): void;
     public _init(file: Gio.File, width: number, height: number, speed: number): void;
 
     public play(): void;
@@ -25,7 +25,7 @@ export class Animation extends St.Bin {
 export class AnimatedIcon extends Animation {
     constructor(file: Gio.File, size: number);
     /** @hidden */
-    public _init(props?: St.Bin.ConstructorProps): void;
+    public _init(props?: Partial<St.Bin.ConstructorProps>): void;
     /** @hidden */
     public _init(file: Gio.File, width: number, height: number, speed: number): void;
     public _init(file: Gio.File, size: number): void;
@@ -34,7 +34,7 @@ export class AnimatedIcon extends Animation {
 export class Spinner extends AnimatedIcon {
     constructor(size: number, params: { animate: boolean; hideOnStop: boolean });
     /** @hidden */
-    public _init(props?: St.Bin.ConstructorProps): void;
+    public _init(props?: Partial<St.Bin.ConstructorProps>): void;
     /** @hidden */
     public _init(file: Gio.File, width: number, height: number, speed: number): void;
     /** @hidden */

--- a/packages/gnome-shell/src/ui/appDisplay.d.ts
+++ b/packages/gnome-shell/src/ui/appDisplay.d.ts
@@ -13,16 +13,16 @@ export class AppGrid extends IconGrid {
     public indicatorsPadding: number;
 
     /** @hidden */
-    public _init(params?: St.Viewport.ConstructorProps): void;
-    public _init(layoutParams?: IconGrid.ConstructorProps): void;
+    public _init(params?: Partial<St.Viewport.ConstructorProps>): void;
+    public _init(layoutParams?: Partial<IconGrid.ConstructorProps>): void;
 
     protected _updatePadding(): void;
 }
 
 export abstract class BaseAppView extends St.Widget {
     // TODO: 'view-loaded' signal
-    constructor(params?: St.Widget.ConstructorProps);
-    public _init(params?: St.Widget.ConstructorProps): void;
+    constructor(params?: Partial<St.Widget.ConstructorProps>);
+    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
 
     protected _onDestroy(): void;
     protected _createGrid(): AppGrid;
@@ -111,8 +111,8 @@ export class AppViewItem extends St.Button {
     readonly id: string;
     readonly app: any;
 
-    constructor(params?: St.Button.ConstructorProps);
-    public _init(params?: St.Button.ConstructorProps, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
+    constructor(params?: Partial<St.Button.ConstructorProps>);
+    public _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
 
     protected _onDestroy(): void;
     protected _updateMultiline(): void;
@@ -136,8 +136,8 @@ export class AppViewItem extends St.Button {
 
 export namespace AppIcon {
     export interface ConstructorProps extends BaseIcon.ConstructorProps {
-        isDraggable?: boolean;
-        expandTitleOnHover?: boolean;
+        isDraggable: boolean;
+        expandTitleOnHover: boolean;
     }
 }
 
@@ -153,8 +153,8 @@ export class AppIcon extends AppViewItem {
     constructor(app: any, iconParams?: AppIcon.ConstructorProps);
 
     /** @hidden */
-    public _init(params?: St.Button.ConstructorProps, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
-    public _init(app: any, iconParams?: AppIcon.ConstructorProps): void;
+    public _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
+    public _init(app: any, iconParams?: Partial<AppIcon.ConstructorProps>): void;
 
     protected _onDestroy(): void;
     protected _createIcon(iconSize: number): St.Widget;

--- a/packages/gnome-shell/src/ui/audioDeviceSelection.d.ts
+++ b/packages/gnome-shell/src/ui/audioDeviceSelection.d.ts
@@ -15,9 +15,9 @@ declare class AudioDeviceSelectionDialog extends ModalDialog {
     constructor(devices: number);
 
     /** @hidden */
-    public _init(params?: St.Widget.ConstructorProps): void;
+    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
     /** @hidden */
-    public _init(props?: ModalDialog.ConstructorProps): void;
+    public _init(props?: Partial<ModalDialog.ConstructorProps>): void;
     public _init(devices: number): void;
 
     protected _buildLayout(): void;

--- a/packages/gnome-shell/src/ui/background.d.ts
+++ b/packages/gnome-shell/src/ui/background.d.ts
@@ -141,7 +141,7 @@ declare class Background extends Meta.Background {
     constructor(params?: { monitorIndex?: number; layoutManager: LayoutManager; settings?: Gio.Settings | null; file: Gio.File | null; style: string | null });
 
     /** @hidden */
-    public _init(params?: Meta.Background.ConstructorProps): void;
+    public _init(params?: Partial<Meta.Background.ConstructorProps>): void;
     public _init(params?: { monitorIndex?: number; layoutManager: LayoutManager; settings?: Gio.Settings | null; file: Gio.File | null; style: string | null }): void;
 
     public destroy(): void;
@@ -165,7 +165,7 @@ export class SystemBackground extends Meta.BackgroundActor {
     constructor();
 
     /** @hidden */
-    public _init(params?: Meta.BackgroundActor.ConstructorProps): void;
+    public _init(params?: Partial<Meta.BackgroundActor.ConstructorProps>): void;
     public _init(): void;
 }
 
@@ -195,7 +195,7 @@ declare class BackgroundSource {
  * wrapper for GnomeBG.BGSlideShow
  */
 declare class Animation extends GnomeBG.BGSlideShow {
-    public _init(params?: GnomeBG.BGSlideShow.ConstructorProps): void;
+    public _init(params?: Partial<GnomeBG.BGSlideShow.ConstructorProps>): void;
 
     /** @hidden */
     load_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback<this> | null): void;

--- a/packages/gnome-shell/src/ui/barLevel.d.ts
+++ b/packages/gnome-shell/src/ui/barLevel.d.ts
@@ -1,7 +1,6 @@
 // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/barLevel.js
 
 import type St from '@girs/st-14';
-import type Atk from '@girs/atk-1.0';
 
 export namespace BarLevel {
     export interface ConstructorProps extends St.DrawingArea.ConstructorProps {}
@@ -17,8 +16,8 @@ export class BarLevel extends St.DrawingArea {
     public maximumValue: number;
     public overdriveStart: number;
 
-    constructor(params?: BarLevel.ConstructorProps);
-    public _init(params?: BarLevel.ConstructorProps): void;
+    constructor(params?: Partial<BarLevel.ConstructorProps>);
+    public _init(params?: Partial<BarLevel.ConstructorProps>): void;
 
     public vfunc_repaint(): void;
 

--- a/packages/gnome-shell/src/ui/boxpointer.d.ts
+++ b/packages/gnome-shell/src/ui/boxpointer.d.ts
@@ -40,16 +40,16 @@ export class BoxPointer extends St.Widget {
      * @param arrowSide side to draw the arrow on
      * @param binProperties Properties to set on contained bin
      */
-    constructor(arrowSide: St.Side, binProperties?: St.Bin.ConstructorProps);
+    constructor(arrowSide: St.Side, binProperties?: Partial<St.Bin.ConstructorProps>);
 
     /** @hidden */
-    public _init(params?: St.Widget.ConstructorProps): void;
+    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
 
     /**
      * @param arrowSide side to draw the arrow on
      * @param binProperties Properties to set on contained bin
      */
-    public _init(arrowSide: St.Side, binProperties?: St.Bin.ConstructorProps): void;
+    public _init(arrowSide: St.Side, binProperties?: Partial<St.Bin.ConstructorProps>): void;
 
     public vfunc_captured_event(event: Clutter.Event): boolean;
 

--- a/packages/gnome-shell/src/ui/calendar.d.ts
+++ b/packages/gnome-shell/src/ui/calendar.d.ts
@@ -139,7 +139,7 @@ export class Calendar extends St.Widget {
 
     constructor();
     /** @hidden */
-    public _init(params?: St.Widget.ConstructorProps): void;
+    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
     public _init(): void;
 
     public setEventSource(eventSource: EventSourceBase): void;
@@ -164,7 +164,7 @@ export class Calendar extends St.Widget {
 
 export class NotificationMessage extends Message {
     /** @hidden */
-    override _init(params?: St.Button.ConstructorProps): void;
+    override _init(params?: Partial<St.Button.ConstructorProps>): void;
     /** @hidden */
     override _init(title: string, body: string): void;
     public _init(notification: Notification): void;
@@ -180,7 +180,7 @@ declare class TimeLabel extends St.Label {
     _datetime: Date;
 
     /** @hidden */
-    public _init(params?: St.Label.ConstructorProps): void;
+    public _init(params?: Partial<St.Label.ConstructorProps>): void;
     public _init(datetime: Date): void;
 
     public vfunc_map(): void;
@@ -190,7 +190,7 @@ declare class NotificationSection extends MessageListSection {
     public readonly allowed: boolean;
 
     /** @hidden */
-    public _init(params?: St.BoxLayout.ConstructorProps): void;
+    public _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
     public _init(): void;
 
     public vfunc_map(): void;
@@ -205,7 +205,7 @@ declare class Placeholder extends St.BoxLayout {
     protected _label: St.Label;
 
     /** @hidden */
-    override _init(params?: St.BoxLayout.ConstructorProps): void;
+    override _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
     public _init(): void;
 }
 
@@ -214,7 +214,7 @@ declare class DoNotDisturbSwitch extends Switch {
 
     constructor();
     /** @hidden */
-    override _init(config?: St.Bin.ConstructorProps): void;
+    override _init(config?: Partial<St.Bin.ConstructorProps>): void;
     /** @hidden */
     override _init(state: boolean): void;
     public _init(): void;
@@ -233,7 +233,7 @@ export class CalendarMessageList extends St.Widget {
     // visible: boolean;
 
     /** @hidden */
-    override _init(config?: St.Widget.ConstructorProps): void;
+    override _init(config?: Partial<St.Widget.ConstructorProps>): void;
     public _init(): void;
 
     protected _addSection(section: MessageListSection): void;

--- a/packages/gnome-shell/src/ui/checkBox.d.ts
+++ b/packages/gnome-shell/src/ui/checkBox.d.ts
@@ -6,7 +6,7 @@ export class CheckBox extends St.Button {
 
     constructor(label?: string);
     /** @hidden */
-    public _init(params?: St.Button.ConstructorProps): void;
+    public _init(params?: Partial<St.Button.ConstructorProps>): void;
     public _init(label?: string): void;
 
     public setLabel(label: string): void;

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -45,8 +45,8 @@ export class Dialog extends St.Widget {
  */
 export namespace MessageDialogContent {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
-        title?: string;
-        description?: string;
+        title: string;
+        description: string;
     }
 }
 /**
@@ -57,8 +57,8 @@ export class MessageDialogContent extends St.BoxLayout {
     public title: string;
     public description: string;
 
-    constructor(params: MessageDialogContent.ConstructorProps);
-    public _init(params: MessageDialogContent.ConstructorProps): void;
+    constructor(params: Partial<MessageDialogContent.ConstructorProps>);
+    public _init(params: Partial<MessageDialogContent.ConstructorProps>): void;
 
     protected _onDestroy(): void;
     protected _updateTitleStyle(): void | false;
@@ -70,7 +70,7 @@ export class MessageDialogContent extends St.BoxLayout {
  */
 export namespace ListSection {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
-        title?: string;
+        title: string;
     }
 }
 
@@ -85,8 +85,8 @@ export class ListSection extends St.BoxLayout {
     public list: St.BoxLayout;
     public title: string;
 
-    constructor(params: ListSection.ConstructorProps);
-    public _init(params: ListSection.ConstructorProps): void;
+    constructor(params: Partial<ListSection.ConstructorProps>);
+    public _init(params: Partial<ListSection.ConstructorProps>): void;
 }
 
 /**
@@ -95,9 +95,9 @@ export class ListSection extends St.BoxLayout {
  */
 export namespace ListSectionItem {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
-        title?: string;
-        description?: string;
-        iconActor?: Clutter.Actor;
+        title: string;
+        description: string;
+        iconActor: Clutter.Actor;
     }
 }
 
@@ -116,6 +116,6 @@ export class ListSectionItem extends St.BoxLayout {
     constructor(params: { style_class?: string | null });
 
     /** @hidden Defined to resolve version conflicts */
-    public _init(config?: ListSectionItem.ConstructorProps): void;
+    public _init(config?: Partial<ListSectionItem.ConstructorProps>): void;
     public _init(params: { style_class?: string | null }): void;
 }

--- a/packages/gnome-shell/src/ui/dnd.d.ts
+++ b/packages/gnome-shell/src/ui/dnd.d.ts
@@ -30,18 +30,18 @@ export function removeDragMonitor(monitor: _Draggable): void;
 
 declare namespace _Draggable {
     export interface ConstructorProps {
-        manualMode?: boolean;
-        timeoutThreshold?: number;
-        restoreOnSuccess?: boolean;
-        dragActorMaxSize?: number;
-        dragActorOpacity?: number;
+        manualMode: boolean;
+        timeoutThreshold: number;
+        restoreOnSuccess: boolean;
+        dragActorMaxSize: number;
+        dragActorOpacity: number;
     }
 }
 
 declare class _Draggable extends EventEmitter {
     public actor: Clutter.Actor;
 
-    constructor(actor: Clutter.Actor, params: _Draggable.ConstructorProps);
+    constructor(actor: Clutter.Actor, params: Partial<_Draggable.ConstructorProps>);
 
     /**
      * fakeRelease:

--- a/packages/gnome-shell/src/ui/iconGrid.d.ts
+++ b/packages/gnome-shell/src/ui/iconGrid.d.ts
@@ -6,9 +6,9 @@ import type Shell from '@girs/shell-14';
 
 export namespace BaseIcon {
     export interface ConstructorProps {
-        createIcon?: any | null;
-        setSizeManually?: boolean;
-        showLabel?: boolean;
+        createIcon: any | null;
+        setSizeManually: boolean;
+        showLabel: boolean;
     }
 }
 
@@ -19,10 +19,10 @@ export class BaseIcon extends Shell.SquareBin {
 
     protected _setSizeManually?: boolean;
 
-    constructor(label: string, params?: BaseIcon.ConstructorProps);
+    constructor(label: string, params?: Partial<BaseIcon.ConstructorProps>);
 
-    public _init(params?: Shell.SquareBin.ConstructorProps): void;
-    public _init(label: string, params?: BaseIcon.ConstructorProps): void;
+    public _init(params?: Partial<Shell.SquareBin.ConstructorProps>): void;
+    public _init(label: string, params?: Partial<BaseIcon.ConstructorProps>): void;
 }
 
 export namespace IconGrid {
@@ -47,10 +47,10 @@ export class IconGrid extends St.Viewport {
 
     protected _currentPage: number;
 
-    constructor(layoutParams?: IconGrid.ConstructorProps);
+    constructor(layoutParams?: Partial<IconGrid.ConstructorProps>);
 
     /** @hidden */
-    public _init(params?: St.Viewport.ConstructorProps): void;
+    public _init(params?: Partial<St.Viewport.ConstructorProps>): void;
     public _init(layoutParams?: IconGrid.ConstructorProps): void;
 
     protected _childAdded(grid: IconGrid, child: St.Widget): void;

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -32,9 +32,9 @@ export interface Geometry {
 
 export namespace MonitorConstraint {
     export interface ConstructorProps extends Clutter.Constraint.ConstructorProps {
-        primary?: boolean;
-        index?: number;
-        workArea?: boolean;
+        primary: boolean;
+        index: number;
+        workArea: boolean;
     }
 }
 
@@ -51,10 +51,10 @@ export class MonitorConstraint extends Clutter.Constraint {
     public index: number;
     public workArea: boolean;
 
-    constructor(props: MonitorConstraint.ConstructorProps);
+    constructor(props: Partial<MonitorConstraint.ConstructorProps>);
 
     /** @hidden */
-    public _init(props: MonitorConstraint.ConstructorProps): void;
+    public _init(props: Partial<MonitorConstraint.ConstructorProps>): void;
     public _init(): void;
 
     public vfunc_set_actor(actor: Clutter.Actor): void;
@@ -82,8 +82,8 @@ declare class Monitor {
  * @version 46
  */
 declare class UiActor extends St.Widget {
-    public constructor(props?: St.Widget.ConstructorProps);
-    public _init(props?: St.Widget.ConstructorProps): void;
+    public constructor(props?: Partial<St.Widget.ConstructorProps>);
+    public _init(props?: Partial<St.Widget.ConstructorProps>): void;
 
     public vfunc_get_preferred_width(_forHeight: number): [number, number];
     public vfunc_get_preferred_height(_forWidth: number): [number, number];
@@ -97,7 +97,7 @@ declare class ScreenTransition extends Clutter.Actor {
     constructor();
 
     /** @hidden */
-    public _init(params?: Clutter.Actor.ConstructorProps): void;
+    public _init(params?: Partial<Clutter.Actor.ConstructorProps>): void;
     public _init(): void;
 
     public vfunc_hide(): void;
@@ -121,7 +121,7 @@ declare class HotCorner extends Clutter.Actor {
 
     constructor(layoutManager: LayoutManager, monitor: Monitor, x: number, y: number);
 
-    public _init(props?: Clutter.Actor.ConstructorProps): void;
+    public _init(props?: Partial<Clutter.Actor.ConstructorProps>): void;
     public _init(layoutManager: LayoutManager, monitor: Monitor, x: number, y: number): void;
 
     public setBarrierSize(size: number): void;

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -18,8 +18,8 @@ export const VIGNETTE_SHARPNESS = 0.7;
  */
 export namespace RadialShaderEffect {
     export interface ConstructorProps extends Shell.GLSLEffect.ConstructorProps {
-        brightness?: number;
-        sharpness?: number;
+        brightness: number;
+        sharpness: number;
     }
 }
 
@@ -34,8 +34,8 @@ export class RadialShaderEffect extends Shell.GLSLEffect {
     public brightness: number;
     public sharpness: number;
 
-    constructor(props: RadialShaderEffect.ConstructorProps);
-    public _init(props: RadialShaderEffect.ConstructorProps): void;
+    constructor(props: Partial<RadialShaderEffect.ConstructorProps>);
+    public _init(props: Partial<RadialShaderEffect.ConstructorProps>): void;
 
     vfunc_build_pipeline(): void;
 }
@@ -56,8 +56,8 @@ export interface LightboxAdditionalParameters {
  */
 export namespace Lightbox {
     export interface ConstructorProps extends St.Bin.ConstructorProps, LightboxAdditionalParameters {
-        brightness?: number;
-        sharpness?: number;
+        brightness: number;
+        sharpness: number;
     }
 }
 
@@ -93,8 +93,8 @@ export class Lightbox extends St.Bin {
      * @param {number=} params.fadeFactor: fading opacity factor
      * @param {boolean=} params.radialEffect: whether to enable the GLSL radial effect
      */
-    constructor(container: Clutter.Actor, params?: Lightbox.ConstructorProps);
-    public _init(container: Clutter.Actor, params?: Lightbox.ConstructorProps): void;
+    constructor(container: Clutter.Actor, params?: Partial<Lightbox.ConstructorProps>);
+    public _init(container: Clutter.Actor, params?: Partial<Lightbox.ConstructorProps>): void;
 
     lightOn(fadeInTime?: number): void;
     lightOff(fadeOutTime?: number): void;

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -18,7 +18,7 @@ export class URLHighlighter extends St.Label {
     constructor(text?: string, lineWrap?: boolean, allowMarkup?: boolean);
 
     /** @hidden */
-    public _init(params?: St.Label.ConstructorProps): void;
+    public _init(params?: Partial<St.Label.ConstructorProps>): void;
     public _init(text?: string, lineWrap?: boolean, allowMarkup?: boolean): void;
 
     public vfunc_button_press_event(buttonEvent: Clutter.ButtonEvent): boolean;
@@ -38,7 +38,7 @@ export declare namespace Source {
         iconName: string | null;
     }
 
-    type ConstructorProps = Partial<Source.ObjectProperties> & GObject.Object.ConstructorProps;
+    type ConstructorProps = Partial<Source.ObjectProperties> & Partial<GObject.Object.ConstructorProps>;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/messageTray.d.ts
+++ b/packages/gnome-shell/src/ui/messageTray.d.ts
@@ -188,7 +188,7 @@ export namespace Notification {
  */
 export declare namespace Source {
     export interface ConstructorProps extends MessageList.Source.ConstructorProps {
-        policy?: NotificationPolicy;
+        policy: NotificationPolicy;
     }
 }
 
@@ -197,7 +197,7 @@ export declare namespace Source {
  * @version 46
  */
 export class Source extends MessageList.Source {
-    constructor(params?: Source.ConstructorProps);
+    constructor(params?: Partial<Source.ConstructorProps>);
 
     public readonly notifications: readonly Notification[];
 
@@ -263,7 +263,7 @@ export declare namespace Notification {
         isTransient: boolean;
     }
 
-    export type ConstructorProps = Partial<ObjectProperties> & GObject.Object.ConstructorProps;
+    export type ConstructorProps = Partial<ObjectProperties> & Partial<GObject.Object.ConstructorProps>;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -25,11 +25,11 @@ export enum State {
  */
 export namespace ModalDialog {
     export interface ConstructorProps extends St.Widget.ConstructorProps {
-        shellReactive?: boolean;
-        actionMode?: Shell.ActionMode;
-        shouldFadeIn?: boolean;
-        shouldFadeOut?: boolean;
-        destroyOnClose?: boolean;
+        shellReactive: boolean;
+        actionMode: Shell.ActionMode;
+        shouldFadeIn: boolean;
+        shouldFadeOut: boolean;
+        destroyOnClose: boolean;
     }
 }
 
@@ -57,9 +57,9 @@ export class ModalDialog extends St.Widget {
     public buttonLayout: Dialog['buttonLayout'];
     public state: State;
 
-    constructor(params?: ModalDialog.ConstructorProps);
+    constructor(params?: Partial<ModalDialog.ConstructorProps>);
 
-    public _init(params?: ModalDialog.ConstructorProps): void;
+    public _init(params?: Partial<ModalDialog.ConstructorProps>): void;
 
     protected _setState(state: State): void;
     protected _fadeOpen(onPrimary: boolean): void;

--- a/packages/gnome-shell/src/ui/mpris.d.ts
+++ b/packages/gnome-shell/src/ui/mpris.d.ts
@@ -18,7 +18,7 @@ declare class MediaMessage extends Message {
     constructor(player: MprisPlayer);
 
     /** @hidden */
-    public override _init(params?: St.Button.ConstructorProps): void;
+    public override _init(params?: Partial<St.Button.ConstructorProps>): void;
     /** @hidden */
     public override _init(title: string, body: string): void;
     public _init(player: MprisPlayer): void;
@@ -57,7 +57,7 @@ export class MediaSection extends MessageListSection {
     public readonly allowed: boolean;
 
     /** @hidden */
-    public _init(params?: St.BoxLayout.ConstructorProps): void;
+    public _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
     public _init(): void;
 
     _addPlayer(busName: string): void;

--- a/packages/gnome-shell/src/ui/panelMenu.d.ts
+++ b/packages/gnome-shell/src/ui/panelMenu.d.ts
@@ -18,10 +18,9 @@ declare namespace ButtonBox {
  * @version 46
  */
 declare class ButtonBox extends St.Widget {
-    constructor(params?: ButtonBox.ConstructorProps);
-
+    constructor(params?: Partial<ButtonBox.ConstructorProps>);
     /** @hidden Defined to resolve version conflicts */
-    _init(params: ButtonBox.ConstructorProps): void;
+    _init(params: Partial<ButtonBox.ConstructorProps>): void;
     container: St.Bin;
 
     public vfunc_get_preferred_width(_forHeight: number): [number, number];
@@ -48,7 +47,7 @@ export class Button extends ButtonBox {
     constructor(menuAlignment: number, nameText: string, dontCreateMenu?: boolean);
 
     /** @hidden Defined to resolve version conflicts */
-    _init(params?: Button.ConstructorProps): void;
+    _init(params?: Partial<ButtonBox.ConstructorProps>): void;
     _init(menuAlignment: number, nameText: string, dontCreateMenu?: boolean): void;
 
     setSensitive(sensitive: boolean): void;

--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -32,11 +32,11 @@ export function arrowIcon(side: St.Side): St.Icon;
  */
 declare namespace PopupBaseMenuItem {
     export interface ConstructorProps {
-        reactive?: boolean;
-        activate?: boolean;
-        hover?: boolean;
-        style_class?: string;
-        can_focus?: boolean;
+        reactive: boolean;
+        activate: boolean;
+        hover: boolean;
+        style_class: string;
+        can_focus: boolean;
     }
 }
 
@@ -49,7 +49,7 @@ declare class PopupBaseMenuItem extends St.BoxLayout {
     active: boolean;
     sensitive: boolean;
 
-    constructor(params?: PopupBaseMenuItem.ConstructorProps);
+    constructor(params?: Partial<PopupBaseMenuItem.ConstructorProps>);
     override _init(...args: any[]): void;
 
     activate(event: Clutter.Event): void;
@@ -83,8 +83,8 @@ export namespace PopupMenuItem {
  * @version 46
  */
 export class PopupMenuItem extends PopupBaseMenuItem {
-    constructor(text: string, params?: PopupMenuItem.ConstructorProps);
-    override _init(text: string, params?: PopupMenuItem.ConstructorProps): void;
+    constructor(text: string, params?: Partial<PopupMenuItem.ConstructorProps>);
+    override _init(text: string, params?: Partial<PopupMenuItem.ConstructorProps>): void;
 
     readonly label: St.Label;
 }

--- a/packages/gnome-shell/src/ui/quickSettings.d.ts
+++ b/packages/gnome-shell/src/ui/quickSettings.d.ts
@@ -18,7 +18,7 @@ export declare class QuickSettingsItem extends St.Button {
     /**
      * Initializes a new instance of `QuickSettingsItem`.
      */
-    _init(config?: St.Button.ConstructorProps): void;
+    _init(config?: Partial<St.Button.ConstructorProps>): void;
 }
 
 /**
@@ -37,7 +37,7 @@ export declare class QuickToggle extends QuickSettingsItem {
     /**
      * Initializes a new instance of `QuickToggle`.
      */
-    _init(params: St.Button.ConstructorProps): void;
+    _init(params: Partial<St.Button.ConstructorProps>): void;
 
     get label(): string;
     set label(label: string);
@@ -58,7 +58,7 @@ export declare class QuickMenuToggle extends QuickSettingsItem {
     /**
      * Initializes a new instance of `QuickMenuToggle`.
      */
-    _init(params: St.Button.ConstructorProps): void;
+    _init(params: Partial<St.Button.ConstructorProps>): void;
 }
 
 /**
@@ -77,7 +77,7 @@ export declare class QuickSlider extends QuickSettingsItem {
     /**
      * Initializes a new instance of `QuickSlider`.
      */
-    _init(params: St.Button.ConstructorProps): void;
+    _init(params: Partial<St.Button.ConstructorProps>): void;
 }
 
 /**
@@ -160,9 +160,9 @@ export declare class QuickSettingsLayout extends Clutter.LayoutManager {
     /**
      * Initializes a new instance of QuickSettingsLayout.
      */
-    constructor(overlay: Clutter.Actor, params?: Clutter.LayoutManager.ConstructorProps);
+    constructor(overlay: Clutter.Actor, params?: Partial<Clutter.LayoutManager.ConstructorProps>);
 
-    _init(overlay: Clutter.Actor, params?: Clutter.LayoutManager.ConstructorProps): void;
+    _init(overlay: Clutter.Actor, params?: Partial<Clutter.LayoutManager.ConstructorProps>): void;
 
     /**
      * Method to get child metadata type.

--- a/packages/gnome-shell/src/ui/search.d.ts
+++ b/packages/gnome-shell/src/ui/search.d.ts
@@ -9,7 +9,7 @@ export class MaxWidthBox extends St.BoxLayout {}
 
 export class SearchResult extends St.Button {
     /** @hidden */
-    public _init(config?: St.Button.ConstructorProps): void;
+    public _init(config?: Partial<St.Button.ConstructorProps>): void;
     public _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
 
     activate(): void;
@@ -17,7 +17,7 @@ export class SearchResult extends St.Button {
 
 export class ListSearchResult extends SearchResult {
     /** @hidden */
-    public _init(config?: St.Button.ConstructorProps): void;
+    public _init(config?: Partial<St.Button.ConstructorProps>): void;
     public _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
 }
 
@@ -25,7 +25,7 @@ export class GridSearchResult extends SearchResult {
     public readonly focusChild: St.Widget;
 
     /** @hidden */
-    public _init(config?: St.Button.ConstructorProps): void;
+    public _init(config?: Partial<St.Button.ConstructorProps>): void;
     public _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
 
     protected _onDestroy(): void;
@@ -39,7 +39,7 @@ export class GridSearchResult extends SearchResult {
 
 export abstract class SearchResultsBase extends St.BoxLayout {
     /** @hidden */
-    public _init(config?: St.BoxLayout.ConstructorProps): void;
+    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     /** @hidden */
     public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
     public _init(props?: { style_class?: string; vertical?: boolean }): void;
@@ -53,7 +53,7 @@ export abstract class SearchResultsBase extends St.BoxLayout {
 
 export class ListSearchResults extends SearchResultsBase {
     /** @hidden */
-    public _init(config?: St.BoxLayout.ConstructorProps): void;
+    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     /** @hidden */
     public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
     /** @hidden */
@@ -74,7 +74,7 @@ export class GridSearchResultsLayout extends Clutter.LayoutManager {
     public spacing: number;
 
     /** @hidden */
-    public _init(config?: Clutter.LayoutManager.ConstructorProps): void;
+    public _init(config?: Partial<Clutter.LayoutManager.ConstructorProps>): void;
     public _init(): void;
 
     public columnsForWidth(width: number): number;
@@ -82,7 +82,7 @@ export class GridSearchResultsLayout extends Clutter.LayoutManager {
 
 export class GridSearchResults extends SearchResultsBase {
     /** @hidden */
-    public _init(config?: St.BoxLayout.ConstructorProps): void;
+    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     /** @hidden */
     public _init(props?: { style_class?: string; vertical?: boolean }): void;
 
@@ -103,7 +103,7 @@ export class SearchResultsView extends St.BoxLayout {
     public readonly searchInProgress: boolean;
 
     /** @hidden */
-    public _init(config?: St.BoxLayout.ConstructorProps): void;
+    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     public _init(): void;
 
     protected _reloadRemoteProviders(): void;
@@ -135,7 +135,7 @@ export class ProviderInfo extends St.Button {
     readonly PROVIDER_ICON_SIZE: number;
 
     /** @hidden */
-    public _init(config?: St.Button.ConstructorProps): void;
+    public _init(config?: Partial<St.Button.ConstructorProps>): void;
 
     public _init(provider: AppSearchProvider): void;
 

--- a/packages/gnome-shell/src/ui/switcherPopup.d.ts
+++ b/packages/gnome-shell/src/ui/switcherPopup.d.ts
@@ -6,7 +6,7 @@ import type Clutter from '@girs/clutter-14';
 
 export abstract class SwitcherPopup extends St.Widget {
     /** @hidden Only defined to resolve type conflict */
-    _init(props: St.Widget.ConstructorProps): void;
+    _init(props: Partial<St.Widget.ConstructorProps>): void;
     _init(items: any[]): void;
 
     _initialSelection(backward: boolean, _binding?: any): void;
@@ -62,7 +62,7 @@ export abstract class SwitcherPopup extends St.Widget {
 
 export class SwitcherList extends St.Widget {
     /** @hidden Defined only to resolve type conflicts */
-    _init(config?: St.Widget.ConstructorProps): void;
+    _init(config?: Partial<St.Widget.ConstructorProps>): void;
     _init(squareItems: any[]): void;
 
     addItem(item: any, label: string): void;


### PR DESCRIPTION
Since the new Beta of `ts-for-gir` the approach to optional parameters has changed, now everywhere `Partial<XY.ConstructorProps>` is used, instead of declaring each property in the `ConstructorProps` `property?: xy `

This breaks many things, and they all have to be changed, this wasn't caught before, since apparently no-one (including me) used the `4.0.0-beta.2` types.

I'll try to find all places and then squash it into one commit.


Here's a fun screenshot, of using this types with the `beta-2` packages:

![image](https://github.com/gjsify/gnome-shell/assets/32566573/19686221-8494-49ab-ad07-dea32588bf10)
