### PR TITLE
declarations cleanup

### DIFF
--- a/packages/gnome-shell/src/extensions/extension.d.ts
+++ b/packages/gnome-shell/src/extensions/extension.d.ts
@@ -1,5 +1,4 @@
 export type { ExtensionMetadata } from '../types/extension-metadata.js';
-import type { ExtensionType, ExtensionState } from '../misc/extensionUtils.js';
 import type { ExtensionBase, TranslationFunctions } from './sharedInternals.js';
 export class Extension extends ExtensionBase {
     static defineTranslationFunctions(url: string): TranslationFunctions;

--- a/packages/gnome-shell/src/ui/components/automountManager.d.ts
+++ b/packages/gnome-shell/src/ui/components/automountManager.d.ts
@@ -1,5 +1,10 @@
 // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/components/automountManager.js
 
+/**
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/components/automountManager.js#L19
+ * @version 46
+ */
 declare class AutomountManager {
     constructor();
 

--- a/packages/gnome-shell/src/ui/components/automountManager.d.ts
+++ b/packages/gnome-shell/src/ui/components/automountManager.d.ts
@@ -1,4 +1,4 @@
-import './automountManager-ambient';
+// https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/components/automountManager.js
 
 declare class AutomountManager {
     constructor();

--- a/packages/gnome-shell/src/ui/components/autorunManager.d.ts
+++ b/packages/gnome-shell/src/ui/components/autorunManager.d.ts
@@ -1,5 +1,10 @@
 // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/components/autorunManager.js
 
+/**
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/components/autorunManager.js#L127
+ * @version 46
+ */
 declare class AutorunManager {
     constructor();
 

--- a/packages/gnome-shell/src/ui/components/autorunManager.d.ts
+++ b/packages/gnome-shell/src/ui/components/autorunManager.d.ts
@@ -1,4 +1,4 @@
-import './autorunManager-ambient';
+// https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/components/autorunManager.js
 
 declare class AutorunManager {
     constructor();


### PR DESCRIPTION
1. Removed import of ExtensionType and ExtensionState, which are not used in the file
2. Removed unnecessary ambient imports
3. Added comments for consistency with other files