### PR TITLE
update types

### DIFF
--- a/packages/gnome-shell/src/misc/dbusUtils.d.ts
+++ b/packages/gnome-shell/src/misc/dbusUtils.d.ts
@@ -2,14 +2,23 @@
 
 /**
  * Load an interface xml file
- * @param iface iface the interface name
- * @returns the interface XML or null if not found
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/dbusUtils.js#L26
+ * @version 46
+ *
+ * @param {string} iface the interface name
+ * @returns {string | null} the XML string or null if it is not found
  */
 export function loadInterfaceXML(iface: string): string | null;
 
 /**
- * Load an subinterface xml file
- * @param iface the interface name
- * @param ifaceFile the interface XML string or null if it is not found
+ * Load a subinterface xml file
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/dbusUtils.js#L47
+ * @version 46
+ *
+ * @param {string} iface the interface name
+ * @param {string} ifaceFile the interface filename
+ * @returns {string | null} the XML string or null if it is not found
  */
 export function loadSubInterfaceXML(iface: string, ifaceFile: string): string | null;

--- a/packages/gnome-shell/src/misc/fileUtils.d.ts
+++ b/packages/gnome-shell/src/misc/fileUtils.d.ts
@@ -1,6 +1,7 @@
 // https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/fileUtils.js
 
 import type Gio from '@girs/gio-2.0';
+export { loadInterfaceXML } from './dbusUtils.js';
 
 export interface SubdirInfo {
     dir: Gio.File;
@@ -31,20 +32,3 @@ export function recursivelyDeleteDir(dir: Gio.File, deleteParent: boolean): void
  * @param {Gio.File} destDir - the file object for the destination directory
  */
 export function recursivelyMoveDir(srcDir: Gio.File, destDir: Gio.File): void;
-
-/**
- * Load an interface xml file
- *
- * @param {string} iface the interface name
- * @returns {string | null} the XML string or null if it is not found
- */
-export function loadInterfaceXML(iface: string): string | null;
-
-/**
- * Load a subinterface xml file
- *
- * @param {string} iface the interface name
- * @param {string} ifaceFile the interface filename
- * @returns {string | null} the XML string or null if it is not found
- */
-export function loadSubInterfaceXML(iface: string, ifaceFile: string): string | null;

--- a/packages/gnome-shell/src/misc/fileUtils.d.ts
+++ b/packages/gnome-shell/src/misc/fileUtils.d.ts
@@ -33,13 +33,14 @@ export function recursivelyDeleteDir(dir: Gio.File, deleteParent: boolean): void
 export function recursivelyMoveDir(srcDir: Gio.File, destDir: Gio.File): void;
 
 /**
- * Load an interface xml file
- * @param {string} name - the name of the interface file to load
+ * @param {string} iface the interface name
+ * @returns {string | null} the XML string or null if it is not found
  */
-export var loadInterfaceXML: (name: string) => any;
+export function loadInterfaceXML(iface: string): string | null;
 
 /**
- * Load an subinterface xml file
- * @param {string} name - the name of the subinterface file to load
+ * @param {string} iface the interface name
+ * @param {string} ifaceFile the interface filename
+ * @returns {string | null} the XML string or null if it is not found
  */
-export function loadSubInterfaceXML(name: string): any;
+export function loadSubInterfaceXML(iface: string, ifaceFile: string): string | null;

--- a/packages/gnome-shell/src/misc/fileUtils.d.ts
+++ b/packages/gnome-shell/src/misc/fileUtils.d.ts
@@ -34,7 +34,7 @@ export function recursivelyMoveDir(srcDir: Gio.File, destDir: Gio.File): void;
 
 /**
  * Load an interface xml file
- * 
+ *
  * @param {string} iface the interface name
  * @returns {string | null} the XML string or null if it is not found
  */
@@ -42,7 +42,7 @@ export function loadInterfaceXML(iface: string): string | null;
 
 /**
  * Load a subinterface xml file
- * 
+ *
  * @param {string} iface the interface name
  * @param {string} ifaceFile the interface filename
  * @returns {string | null} the XML string or null if it is not found

--- a/packages/gnome-shell/src/misc/fileUtils.d.ts
+++ b/packages/gnome-shell/src/misc/fileUtils.d.ts
@@ -33,12 +33,16 @@ export function recursivelyDeleteDir(dir: Gio.File, deleteParent: boolean): void
 export function recursivelyMoveDir(srcDir: Gio.File, destDir: Gio.File): void;
 
 /**
+ * Load an interface xml file
+ * 
  * @param {string} iface the interface name
  * @returns {string | null} the XML string or null if it is not found
  */
 export function loadInterfaceXML(iface: string): string | null;
 
 /**
+ * Load a subinterface xml file
+ * 
  * @param {string} iface the interface name
  * @param {string} ifaceFile the interface filename
  * @returns {string | null} the XML string or null if it is not found

--- a/packages/gnome-shell/src/ui/quickSettings.d.ts
+++ b/packages/gnome-shell/src/ui/quickSettings.d.ts
@@ -24,8 +24,8 @@ export declare class QuickSettingsItem extends St.Button {
  * Class representing a quick toggle item.
  */
 export declare class QuickToggle extends QuickSettingsItem {
-    title: string;
-    subtitle: string;
+    title: string | null;
+    subtitle: string | null;
     gicon: Gio.Icon;
 
     private _box: St.BoxLayout;
@@ -46,8 +46,8 @@ export declare class QuickToggle extends QuickSettingsItem {
  * Class representing a quick menu toggle.
  */
 export declare class QuickMenuToggle extends QuickSettingsItem {
-    title: string;
-    subtitle: string;
+    title: string | null;
+    subtitle: string | null;
     gicon: Gio.Icon;
     menuEnabled: boolean;
 

--- a/packages/gnome-shell/src/ui/quickSettings.d.ts
+++ b/packages/gnome-shell/src/ui/quickSettings.d.ts
@@ -22,6 +22,9 @@ export declare class QuickSettingsItem extends St.Button {
 
 /**
  * Class representing a quick toggle item.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L43
+ * @version 46
  */
 export declare class QuickToggle extends QuickSettingsItem {
     title: string | null;
@@ -44,6 +47,9 @@ export declare class QuickToggle extends QuickSettingsItem {
 
 /**
  * Class representing a quick menu toggle.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L144
+ * @version 46
  */
 export declare class QuickMenuToggle extends QuickSettingsItem {
     title: string | null;


### PR DESCRIPTION
1. loadInterfaceXML, loadSubInterfaceXML are taken from https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/dbusUtils.js?ref_type=heads
2. title, subtitle can be null according to https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js?ref_type=heads