### PR TITLE
ui/quickSettings.d.ts: add constructor props

### DIFF
--- a/packages/gnome-shell/src/ui/quickSettings.d.ts
+++ b/packages/gnome-shell/src/ui/quickSettings.d.ts
@@ -8,25 +8,55 @@ import * as PopupMenu from './popupMenu.js';
 import { Slider } from './slider.js';
 
 /**
- * Class representing a quick settings item.
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L21
+ * @version 46
  */
-export declare class QuickSettingsItem extends St.Button {
+export namespace QuickSettingsItem {
+    interface ConstructorProps extends St.Button.ConstructorProps {
+        hasMenu: boolean;
+    }
+}
+
+/**
+ * Class representing a quick settings item.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L29
+ * @version 46
+ */
+export class QuickSettingsItem extends St.Button {
     hasMenu: boolean;
     menu: QuickToggleMenu;
 
     /**
-     * Initializes a new instance of `QuickSettingsItem`.
+     * Initializes a new instance of `QuickToggle`.
      */
-    _init(config?: Partial<St.Button.ConstructorProps>): void;
+    constructor(params?: Partial<QuickSettingsItem.ConstructorProps>);
+
+    /**
+     * Initializes a new instance of `QuickToggle`.
+     */
+    _init(params?: Partial<QuickSettingsItem.ConstructorProps>): void;
+}
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L43
+ * @version 46
+ */
+export namespace QuickToggle {
+    interface ConstructorProps extends St.Button.ConstructorProps {
+        title: string | null;
+        subtitle: string | null;
+        gicon: Gio.Icon;
+    }
 }
 
 /**
  * Class representing a quick toggle item.
  *
- * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L43
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L56
  * @version 46
  */
-export declare class QuickToggle extends QuickSettingsItem {
+export class QuickToggle extends QuickSettingsItem {
     title: string | null;
     subtitle: string | null;
     gicon: Gio.Icon;
@@ -39,19 +69,37 @@ export declare class QuickToggle extends QuickSettingsItem {
     /**
      * Initializes a new instance of `QuickToggle`.
      */
-    _init(params: Partial<St.Button.ConstructorProps>): void;
+    constructor(params?: Partial<QuickToggle.ConstructorProps>);
+
+    /**
+     * Initializes a new instance of `QuickToggle`.
+     */
+    _init(params?: Partial<QuickToggle.ConstructorProps>): void;
 
     get label(): string;
     set label(label: string);
 }
 
 /**
- * Class representing a quick menu toggle.
- *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L144
  * @version 46
  */
-export declare class QuickMenuToggle extends QuickSettingsItem {
+export namespace QuickMenuToggle {
+    interface ConstructorProps extends St.Button.ConstructorProps {
+        title: string | null;
+        subtitle: string | null;
+        gicon: Gio.Icon;
+        menuEnabled: boolean;
+    }
+}
+
+/**
+ * Class representing a quick menu toggle.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L161
+ * @version 46
+ */
+export class QuickMenuToggle extends QuickSettingsItem {
     title: string | null;
     subtitle: string | null;
     gicon: Gio.Icon;
@@ -63,13 +111,34 @@ export declare class QuickMenuToggle extends QuickSettingsItem {
     /**
      * Initializes a new instance of `QuickMenuToggle`.
      */
-    _init(params: Partial<St.Button.ConstructorProps>): void;
+    constructor(params?: Partial<QuickMenuToggle.ConstructorProps>);
+
+    /**
+     * Initializes a new instance of `QuickMenuToggle`.
+     */
+    _init(params?: Partial<QuickMenuToggle.ConstructorProps>): void;
+}
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L235
+ * @version 46
+ */
+export namespace QuickSlider {
+    interface ConstructorProps extends St.Button.ConstructorProps {
+        gicon: Gio.Icon;
+        iconReactive: boolean;
+        iconLabel: string;
+        menuEnabled: boolean;
+    }
 }
 
 /**
  * Class representing a quick slider.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L257
+ * @version 46
  */
-export declare class QuickSlider extends QuickSettingsItem {
+export class QuickSlider extends QuickSettingsItem {
     gicon: Gio.Icon;
     iconReactive: boolean;
     iconLabel: string;
@@ -78,18 +147,29 @@ export declare class QuickSlider extends QuickSettingsItem {
 
     private _icon: St.Icon;
     private _iconButton: St.Button;
+    private _menuButton: St.Button;
 
     /**
      * Initializes a new instance of `QuickSlider`.
      */
-    _init(params: Partial<St.Button.ConstructorProps>): void;
+    constructor(params?: Partial<QuickSlider.ConstructorProps>);
+
+    /**
+     * Initializes a new instance of `QuickSlider`.
+     */
+    _init(params?: Partial<QuickSlider.ConstructorProps>): void;
 }
 
 /**
  * Class representing a quick toggle menu.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L350
+ * @version 46
  */
-export declare class QuickToggleMenu extends PopupMenu.PopupMenuBase {
-    header: St.Widget;
+export class QuickToggleMenu extends PopupMenu.PopupMenuBase {
+    actor: St.Widget;
+
+    private _header: St.Widget;
     private _headerIcon: St.Icon;
     private _headerTitle: St.Label;
     private _headerSubtitle: St.Label;
@@ -114,29 +194,17 @@ export declare class QuickToggleMenu extends PopupMenu.PopupMenuBase {
     close(animate: boolean): void;
 
     private _syncChecked(): void;
-}
 
-/**
- * Class representing a system indicator.
- */
-export declare class SystemIndicator extends St.BoxLayout {
-    quickSettingsItems: QuickSettingsItem[];
-
-    /**
-     * Initializes a new instance of `SystemIndicator`.
-     */
-    _init(): void;
-
-    /**
-     * Adds an indicator to the system indicator.
-     */
-    _addIndicator(): St.Icon;
+    private _setOpenedSubMenu(submenu: PopupMenu.PopupSubMenu | null): void;
 }
 
 /**
  * Layout metadata for QuickSettingsLayout.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L519
+ * @version 46
  */
-export declare class QuickSettingsLayoutMeta extends Clutter.LayoutMeta {
+export class QuickSettingsLayoutMeta extends Clutter.LayoutMeta {
     /**
      * The span of a child widget in grid columns.
      */
@@ -145,8 +213,11 @@ export declare class QuickSettingsLayoutMeta extends Clutter.LayoutMeta {
 
 /**
  * Custom layout manager for QuickSettingsMenu.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L536
+ * @version 46
  */
-export declare class QuickSettingsLayout extends Clutter.LayoutManager {
+export class QuickSettingsLayout extends Clutter.LayoutManager {
     /**
      * Spacing between rows.
      */
@@ -163,10 +234,18 @@ export declare class QuickSettingsLayout extends Clutter.LayoutManager {
     nColumns: number;
 
     /**
+     * Overlay actor passed to the constructor
+     */
+    private _overlay: Clutter.Actor;
+
+    /**
      * Initializes a new instance of QuickSettingsLayout.
      */
     constructor(overlay: Clutter.Actor, params?: Partial<Clutter.LayoutManager.ConstructorProps>);
 
+    /**
+     * Initializes a new instance of QuickSettingsLayout.
+     */
     _init(overlay: Clutter.Actor, params?: Partial<Clutter.LayoutManager.ConstructorProps>): void;
 
     /**
@@ -194,6 +273,7 @@ export declare class QuickSettingsLayout extends Clutter.LayoutManager {
      */
     vfunc_allocate(container: Clutter.Actor, box: Clutter.ActorBox): void;
 
+    private _containerStyleChanged(): void;
     private _getColSpan(container: Clutter.Actor, child: Clutter.Actor): number;
     private _getMaxChildWidth(container: Clutter.Actor): [number, number];
     private _getRows(container: Clutter.Actor): Clutter.Actor[][];
@@ -202,8 +282,11 @@ export declare class QuickSettingsLayout extends Clutter.LayoutManager {
 
 /**
  * Class representing the QuickSettingsMenu.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L708
+ * @version 46
  */
-export declare class QuickSettingsMenu extends PopupMenu.PopupMenu {
+export class QuickSettingsMenu extends PopupMenu.PopupMenu {
     private _dimEffect: Clutter.BrightnessContrastEffect;
     private _boxPointer: St.Widget;
     private _grid: St.Widget;
@@ -234,4 +317,29 @@ export declare class QuickSettingsMenu extends PopupMenu.PopupMenu {
 
     private _completeAddItem(item: Clutter.Actor, colSpan: number): void;
     private _setDimmed(dim: boolean): void;
+}
+
+/**
+ * Class representing a system indicator.
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/quickSettings.js#L832
+ * @version 46
+ */
+export class SystemIndicator extends St.BoxLayout {
+    quickSettingsItems: QuickSettingsItem[];
+
+    /**
+     * Initializes a new instance of `SystemIndicator`.
+     */
+    _init(): void;
+
+    /**
+     * Sets the visibility of the indicator based on the visibility of its children
+     */
+    _syncIndicatorsVisible(): void;
+
+    /**
+     * Adds an indicator to the system indicator.
+     */
+    _addIndicator(): St.Icon;
 }


### PR DESCRIPTION
Also contains general improvements such as addition of missing types

closes #40 