### PR TITLE
Fix ambient import

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gjsify/gnome-shell-hello-world-example",
-  "version": "46.0.0-beta8",
+  "version": "46.0.0-beta9",
   "description": "Simple Gnome Shell Hello World Extension example",
   "type": "module",
   "main": "dist/extension.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gnome-shell",
-    "version": "46.0.0-beta8",
+    "version": "46.0.0-beta9",
     "description": "GJS TypeScript type definitions for GNOME Shell Extensions",
     "main": "src/index.js",
     "type": "module",

--- a/packages/gnome-shell/package.json
+++ b/packages/gnome-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girs/gnome-shell",
-  "version": "46.0.0-beta8",
+  "version": "46.0.0-beta9",
   "description": "GJS TypeScript type definitions for GNOME Shell Extensions",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnome-shell/src/ui/workspace.d.ts
+++ b/packages/gnome-shell/src/ui/workspace.d.ts
@@ -1,7 +1,7 @@
 import type Clutter from '@girs/clutter-14';
 import type Meta from '@girs/meta-14';
 
-import { WindowPreview } from './windowPreview';
+import { WindowPreview } from './windowPreview.js';
 
 /**
  * @version 46

--- a/packages/gnome-shell/src/ui/workspacesView.d.ts
+++ b/packages/gnome-shell/src/ui/workspacesView.d.ts
@@ -1,4 +1,4 @@
-import { Workspace } from './workspace';
+import { Workspace } from './workspace.js';
 
 /**
  * @version 46


### PR DESCRIPTION
I just tried to upgrade my extension to the latest versions of `@girs/*` packages and noticed that two errors from `tsc`. I would release a new version after approval by one of the other contributors :).

```sh
> tsc --noEmit

node_modules/@girs/gnome-shell/dist/ui/workspace.d.ts:4:31 - error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './windowPreview.js'?

4 import { WindowPreview } from './windowPreview';
                                ~~~~~~~~~~~~~~~~~

node_modules/@girs/gnome-shell/dist/ui/workspacesView.d.ts:1:27 - error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './workspace.js'?

1 import { Workspace } from './workspace';
                            ~~~~~~~~~~~~~


Found 2 errors in 2 files.

Errors  Files
     1  node_modules/@girs/gnome-shell/dist/ui/workspace.d.ts:4
     1  node_modules/@girs/gnome-shell/dist/ui/workspacesView.d.ts:1
```