### PR TITLE
Showcase: Pano Gnome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The TypeScript types for the used libraries are generated from the `.gir` files 
 
 ## Showcase
 * [gTile](https://github.com/gTile/gTile) is a fully typed Gnome extension for tiling and resizing windows
+* [Pano](https://github.com/oae/gnome-shell-pano) is a fully typed Gnome extension that serves as the next-gen Clipboard Manager
 
 We are happy if you link your project through a PR here 😊
 


### PR DESCRIPTION
Same as #46 but for the extension Pano, that also uses many types and is fully typed ❤️ 