### PR TITLE
Adapt typings for Gnome 47 release

### DIFF
--- a/packages/gnome-shell/package.json
+++ b/packages/gnome-shell/package.json
@@ -182,6 +182,17 @@
       }
     },
     "./misc/systemActions/ambient": "./dist/misc/systemActions-ambient.d.ts",
+    "./misc/util": {
+      "import": {
+        "types": "./dist/misc/util.d.ts",
+        "default": "./dist/misc/util.js"
+      },
+      "require": {
+        "types": "./dist/misc/util.d.ts",
+        "default": "./dist/misc/util.cjs"
+      }
+    },
+    "./misc/util/ambient": "./dist/misc/util-ambient.d.ts",
     "./ui/accessDialog": {
       "import": {
         "types": "./dist/ui/accessDialog.d.ts",

--- a/packages/gnome-shell/src/extensions/prefs.d.ts
+++ b/packages/gnome-shell/src/extensions/prefs.d.ts
@@ -1,9 +1,11 @@
 import type Adw from '@girs/adw-1';
 import type Gtk from '@girs/gtk-4.0';
 
-import type { Extension } from './extension.js';
 import type { ExtensionBase, TranslationFunctions } from './sharedInternals.js';
 
+/**
+ * @version 47
+ */
 export class ExtensionPreferences extends ExtensionBase {
     static defineTranslationFunctions(url: string): TranslationFunctions;
 
@@ -11,10 +13,10 @@ export class ExtensionPreferences extends ExtensionBase {
      * Get the single widget that implements
      * the extension's preferences.
      *
-     * @returns {Gtk.Widget}
+     * @returns {Gtk.Widget|Promise<Gtk.Widget>}
      * @throws {GObject.NotImplementedError}
      */
-    getPreferencesWidget(): Gtk.Widget;
+    getPreferencesWidget(): Gtk.Widget | Promise<Gtk.Widget>;
 
     /**
      * Fill the preferences window with preferences.
@@ -24,7 +26,7 @@ export class ExtensionPreferences extends ExtensionBase {
      *
      * @param {Adw.PreferencesWindow} window - the preferences window
      */
-    fillPreferencesWindow(window: Adw.PreferencesWindow): void;
+    fillPreferencesWindow(window: Adw.PreferencesWindow): Promise<void>;
 }
 
 export declare const gettext: TranslationFunctions['gettext'];

--- a/packages/gnome-shell/src/misc/util.d.ts
+++ b/packages/gnome-shell/src/misc/util.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Fix up embedded markup so that it can be displayed correctly in
+ * UI elements such as the message list. In some cases, we might want to
+ * keep some of the embedded markup, so specify allowMarkup for that case
+ *
+ * @version 47
+ *
+ * @param {string} text containing markup to escape and parse
+ * @param {boolean} allowMarkup to allow embedded markup or just escape it all
+ * @returns the escaped string
+ */
+export function fixMarkup(text: string, allowMarkup?: boolean): string;

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -9,11 +9,6 @@ import type Clutter from '@girs/clutter-15';
 /**
  * @version 46
  */
-export function _fixMarkup(text: string, allowMarkup?: boolean): string;
-
-/**
- * @version 46
- */
 export class URLHighlighter extends St.Label {
     constructor(text?: string, lineWrap?: boolean, allowMarkup?: boolean);
 


### PR DESCRIPTION
Based on the changes listed here: https://gjs.guide/extensions/upgrading/gnome-shell-47.html

---

I am going to test integration with [gTile](https://github.com/gTile/gTile) now and will report back whether I stumbled upon any errors.