### PR TITLE
Mark gnome types for 47

### DIFF
--- a/packages/gnome-shell/src/misc/animationUtils.d.ts
+++ b/packages/gnome-shell/src/misc/animationUtils.d.ts
@@ -1,25 +1,48 @@
+// https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js
+
 import type St from '@girs/st-15';
 import type Clutter from '@girs/clutter-15';
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L23
+ * @version 47
+ */
+export interface AdjustAnimationTimeParams {
+    /** whether to ignore the enable-animations setting */
+    animationRequired: boolean;
+}
 
 /**
  * adjustAnimationTime:
  *
  * @param msecs - time in milliseconds
+ * @param params - optional parameters
  *
  * Adjust `msecs` to account for St's enable-animations
  * and slow-down-factor settings
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L22
+ * @version 47
  */
-export function adjustAnimationTime(msecs: number): number;
+
+export function adjustAnimationTime(msecs: number, params?: AdjustAnimationTimeParams): number;
 
 /**
  * Animate scrolling a scrollview until an actor is visible.
  *
  * @param scrollView - the scroll view the actor is in
  * @param actor - the actor
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L40
+ * @version 47
  */
 
 export function ensureActorVisibleInScrollView(scrollView: St.ScrollView, actor: Clutter.Actor): void;
 
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L90
+ * @version 47
+ */
 export interface WiggleParams {
     /** The offset to move the actor by per-wiggle */
     offset: number;
@@ -35,6 +58,9 @@ export interface WiggleParams {
  *
  * @param actor an actor to animate
  * @param params options for the animation
+ *
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L86
+ * @version 47
  */
 
 export function wiggle(actor: Clutter.Actor, params: WiggleParams): void;

--- a/packages/gnome-shell/src/types/extension-metadata.ts
+++ b/packages/gnome-shell/src/types/extension-metadata.ts
@@ -5,7 +5,7 @@ import type Gio from '@girs/gio-2.0';
 /** The Metadata Object for Extensions
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js#L48
- * @version 46
+ * @version 47
  */
 export interface ExtensionMetadata {
     readonly uuid: string;

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -5,7 +5,7 @@ import type St from '@girs/st-15';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L113
- * @version 46
+ * @version 47
  */
 export interface ButtonInfo {
     action: () => void;
@@ -17,7 +17,7 @@ export interface ButtonInfo {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L18
- * @version 46
+ * @version 47
  */
 export class Dialog extends St.Widget {
     protected _parentActor: St.Widget;
@@ -41,7 +41,7 @@ export class Dialog extends St.Widget {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L158
- * @version 46
+ * @version 47
  */
 export namespace MessageDialogContent {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
@@ -51,7 +51,7 @@ export namespace MessageDialogContent {
 }
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L171
- * @version 46
+ * @version 47
  */
 export class MessageDialogContent extends St.BoxLayout {
     public title: string;
@@ -66,7 +66,7 @@ export class MessageDialogContent extends St.BoxLayout {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L250
- * @version 46
+ * @version 47
  */
 export namespace ListSection {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
@@ -76,7 +76,7 @@ export namespace ListSection {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L258
- * @version 46
+ * @version 47
  */
 export class ListSection extends St.BoxLayout {
     protected _listScrollView: St.ScrollView;
@@ -91,7 +91,7 @@ export class ListSection extends St.BoxLayout {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L294
- * @version 46
+ * @version 47
  */
 export namespace ListSectionItem {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
@@ -103,7 +103,7 @@ export namespace ListSectionItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L311
- * @version 46
+ * @version 47
  */
 export class ListSectionItem extends St.BoxLayout {
     protected _iconActorBin: St.Bin;

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -17,7 +17,7 @@ import type { BackgroundManager } from './background.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L159
- * @version 46
+ * @version 47
  */
 export interface Geometry {
     x: number;
@@ -27,7 +27,7 @@ export interface Geometry {
 }
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L41
- * @version 46
+ * @version 47
  */
 
 export namespace MonitorConstraint {
@@ -40,7 +40,7 @@ export namespace MonitorConstraint {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L56
- * @version 46
+ * @version 47
  */
 export class MonitorConstraint extends Clutter.Constraint {
     protected _primary: boolean;
@@ -63,7 +63,7 @@ export class MonitorConstraint extends Clutter.Constraint {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L158
- * @version 46
+ * @version 47
  */
 declare class Monitor {
     public index: number;
@@ -79,7 +79,7 @@ declare class Monitor {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L174
- * @version 46
+ * @version 47
  */
 declare class UiActor extends St.Widget {
     public constructor(props?: Partial<St.Widget.ConstructorProps>);
@@ -91,7 +91,7 @@ declare class UiActor extends St.Widget {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L1454
- * @version 46
+ * @version 47
  */
 declare class ScreenTransition extends Clutter.Actor {
     constructor();
@@ -109,7 +109,7 @@ declare class ScreenTransition extends Clutter.Actor {
  * overview.
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L1141
- * @version 46
+ * @version 47
  */
 declare class HotCorner extends Clutter.Actor {
     protected _entered: boolean;
@@ -137,7 +137,7 @@ declare class HotCorner extends Clutter.Actor {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L186
- * @version 46
+ * @version 47
  */
 export interface TrackedActors {
     trackFullscreen: boolean;
@@ -147,7 +147,7 @@ export interface TrackedActors {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L192
- * @version 46
+ * @version 47
  */
 export class LayoutManager extends GObject.Object {
     protected _rtl: boolean;
@@ -306,9 +306,9 @@ export class LayoutManager extends GObject.Object {
      * of the screen.
      */
     protected _prepareStartupAnimation(): Promise<void>;
-    protected _startupAnimation(): void;
-    protected _startupAnimationGreeter(): void;
-    protected _startupAnimationSession(): void;
+    protected _startupAnimation(): Promise<void>;
+    protected _startupAnimationGreeter(): Promise<void>;
+    protected _startupAnimationSession(): Promise<void>;
     protected _startupAnimationComplete(): void;
     protected _findActor(actor: Clutter.Actor): number;
     protected _trackActor(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
@@ -323,7 +323,7 @@ export class LayoutManager extends GObject.Object {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L1309
- * @version 46
+ * @version 47
  */
 declare class PressureBarrier extends EventEmitter {
     protected _threshold: number;

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -6,7 +6,7 @@ import type Shell from '@girs/shell-15';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L10
- * @version 46
+ * @version 47
  */
 export const DEFAULT_FADE_FACTOR = 0.4;
 export const VIGNETTE_BRIGHTNESS = 0.5;
@@ -14,7 +14,7 @@ export const VIGNETTE_SHARPNESS = 0.7;
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L31
- * @version 46
+ * @version 47
  */
 export namespace RadialShaderEffect {
     export interface ConstructorProps extends Shell.GLSLEffect.ConstructorProps {
@@ -25,7 +25,7 @@ export namespace RadialShaderEffect {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L42
- * @version 46
+ * @version 47
  */
 export class RadialShaderEffect extends Shell.GLSLEffect {
     protected _brightness: number;
@@ -42,7 +42,7 @@ export class RadialShaderEffect extends Shell.GLSLEffect {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L121
- * @version 46
+ * @version 47
  */
 export interface LightboxAdditionalParameters {
     inhibitEvents?: boolean;
@@ -52,7 +52,7 @@ export interface LightboxAdditionalParameters {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L91
- * @version 46
+ * @version 47
  */
 export namespace Lightbox {
     export interface ConstructorProps extends St.Bin.ConstructorProps, LightboxAdditionalParameters {
@@ -63,7 +63,7 @@ export namespace Lightbox {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L96
- * @version 46
+ * @version 47
  */
 export class Lightbox extends St.Bin {
     protected _active: boolean;

--- a/packages/gnome-shell/src/ui/main.d.ts
+++ b/packages/gnome-shell/src/ui/main.d.ts
@@ -27,7 +27,7 @@ import { Panel } from './panel.js';
 // import * as Params from '../misc/params.js'
 // import * as RunDialog from './runDialog.js';
 // import * as WelcomeDialog from './welcomeDialog.js';
-import { LayoutManager } from './layout.js';
+import { LayoutManager, UiActor } from './layout.js';
 // import * as LoginManager from '../misc/loginManager.js'
 // import * as LookingGlass from './lookingGlass.js';
 import { NotificationDaemon } from './notificationDaemon.js';
@@ -100,7 +100,11 @@ export declare const actionMode: Shell.ActionMode.NONE;
 
 export declare const modalActorFocusStack: any[];
 
-export declare const uiGroup: any;
+/**
+ * @deprecated use layoutManager.uiGroup instead
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/main.js#L212
+ */
+export declare const uiGroup: UiActor;
 
 export declare const magnifier: any;
 

--- a/packages/gnome-shell/src/ui/messageTray.d.ts
+++ b/packages/gnome-shell/src/ui/messageTray.d.ts
@@ -228,7 +228,7 @@ export class Source extends MessageList.Source {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L604
- * @version 46
+ * @version 47
  */
 export declare namespace Notification {
     export interface ObjectProperties {

--- a/packages/gnome-shell/src/ui/panelMenu.d.ts
+++ b/packages/gnome-shell/src/ui/panelMenu.d.ts
@@ -7,7 +7,7 @@ import type { PopupMenu, PopupDummyMenu } from './popupMenu.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L11
- * @version 46
+ * @version 47
  */
 declare namespace ButtonBox {
     interface ConstructorProps extends St.Widget.ConstructorProps {}
@@ -15,7 +15,7 @@ declare namespace ButtonBox {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L12
- * @version 46
+ * @version 47
  */
 declare class ButtonBox extends St.Widget {
     constructor(params?: Partial<ButtonBox.ConstructorProps>);
@@ -31,7 +31,7 @@ declare class ButtonBox extends St.Widget {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L95
- * @version 46
+ * @version 47
  */
 export namespace Button {
     interface ConstructorProps extends ButtonBox.ConstructorProps {}
@@ -39,7 +39,7 @@ export namespace Button {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L97
- * @version 46
+ * @version 47
  */
 export class Button extends ButtonBox {
     menu: PopupMenu | PopupDummyMenu;

--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -42,7 +42,7 @@ declare namespace PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L81
- * @version 46
+ * @version 47
  */
 declare class PopupBaseMenuItem extends St.BoxLayout {
     readonly actor: PopupBaseMenuItem;
@@ -105,7 +105,7 @@ export class PopupSeparatorMenuItem extends PopupBaseMenuItem {
 }
 
 /**
- * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L332
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L330
  * @version 47
  */
 export namespace Switch {
@@ -115,10 +115,10 @@ export namespace Switch {
 }
 
 /**
- * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L339
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L337
  * @version 47
  */
-export class Switch extends St.Bin {
+export class Switch extends St.Widget {
     state: boolean;
     constructor(state: boolean);
     /** @hidden Defined only to resolve type conflicts */
@@ -136,6 +136,9 @@ export class Switch extends St.Bin {
     // Specific signal handler methods
     connect(sigName: 'notify::state', callback: ($obj: Switch) => void): number;
     connect_after(sigName: 'notify::state', callback: ($obj: Switch) => void): number;
+
+    vfunc_motion_event(): typeof Clutter.EVENT_PROPAGATE;
+    vfunc_button_release_event(): typeof Clutter.EVENT_PROPAGATE;
 }
 
 /**
@@ -177,7 +180,7 @@ export class PopupSwitchMenuItem extends PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L505
- * @version 46
+ * @version 47
  */
 export namespace PopupImageMenuItem {
     export interface ConstructorProps extends PopupBaseMenuItem.ConstructorProps {}
@@ -361,7 +364,7 @@ export namespace PopupMenuManager {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1321
- * @version 46
+ * @version 47
  */
 export class PopupMenuManager {
     constructor(owner: Clutter.Actor, grabParams?: PopupMenuManager.ConstructorProps);


### PR DESCRIPTION
I checked all modules I use in my extension, and as expected I didn't find many changes.

The last commit may be controversial, as discussed in https://github.com/gjsify/gnome-shell/pull/51 in several comments.


The method `fillPreferencesWindow` is now async, see https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/0f30bfdd531ed0e8ed78bda74d51b7f22872a31b#

But I believe it's better to have a `Promise<void> | void` type, even if the doctoring says, it has to be a Promise, it can also be no promise as the JavaScript usage is only with `await fillPreferencesWindow()` which also works with a non async version of the function. If it would use `.then()` or similar this wouldn't work, but I believe it's better to also allow `void`

See also https://github.com/gjsify/gnome-shell/pull/49#issuecomment-2375364738