### PR TITLE
Add InjectionManager

### DIFF
--- a/packages/gnome-shell/src/extensions/extension.d.ts
+++ b/packages/gnome-shell/src/extensions/extension.d.ts
@@ -12,6 +12,15 @@ export class Extension extends ExtensionBase {
     disable(): void;
 }
 
+/**
+ * @version 47
+ */
+export class InjectionManager {
+    overrideMethod<T, M extends keyof T, F extends T[M] extends (...args: any[]) => any ? T[M] : never>(prototype: T, methodName: M, createOverrideFunc: (this: T, originalMethod: F) => (this: T, ...args: Parameters<F>) => ReturnType<F>): void;
+    restoreMethod<T, M extends keyof T>(prototype: T, methodName: M): void;
+    clear(): void;
+}
+
 export declare const gettext: TranslationFunctions['gettext'];
 export declare const ngettext: TranslationFunctions['ngettext'];
 export declare const pgettext: TranslationFunctions['pgettext'];


### PR DESCRIPTION
The type for overrideMethod is pretty complex to offer proper type checking:

- `T` is an object prototype
- `M` is a field name which must exist on that object
- `T[M]` must be a function
- The override method must have the same signature as the original method
- Inside of the override method, `this` has the type `T`