### PR TITLE
Improve GNOME 48 types

### DIFF
--- a/packages/gnome-shell/src/extensions/sharedInternals.d.ts
+++ b/packages/gnome-shell/src/extensions/sharedInternals.d.ts
@@ -36,8 +36,13 @@ export interface TranslationFunctions {
     pgettext(context: string, str: string): string;
 }
 
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js#L9
+ * @version 48
+ */
 export class ExtensionBase {
     #gettextDomain: string | null;
+    #console: Console;
 
     readonly metadata: ExtensionMetadata;
 
@@ -76,6 +81,8 @@ export class ExtensionBase {
      * @returns {}
      */
     getSettings(schema?: string): Gio.Settings;
+
+    getLogger(): Console;
 
     /**
      * Initialize Gettext to load translations from extensionsdir/locale. If
@@ -141,4 +148,32 @@ export class GettextWrapper {
     #pgettext(context: any, str: string): string;
 
     defineTranslationFunctions(): TranslationFunctions;
+}
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js#L9
+ * @version 48
+ */
+declare class Console {
+    #extension: ExtensionBase;
+
+    constructor(ext: ExtensionBase);
+
+    log(...args: any[]): void;
+
+    warn(...args: any[]): void;
+
+    error(...args: any[]): void;
+
+    info(...args: any[]): void;
+
+    debug(...args: any[]): void;
+
+    assert(condition: boolean, ...args: any[]): void;
+
+    trace(...args: any[]): void;
+
+    group(...args: any[]): void;
+
+    groupEnd(): void;
 }

--- a/packages/gnome-shell/src/misc/animationUtils.d.ts
+++ b/packages/gnome-shell/src/misc/animationUtils.d.ts
@@ -5,7 +5,7 @@ import type Clutter from '@girs/clutter-16';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L23
- * @version 47
+ * @version 48
  */
 export interface AdjustAnimationTimeParams {
     /** whether to ignore the enable-animations setting */
@@ -22,7 +22,7 @@ export interface AdjustAnimationTimeParams {
  * and slow-down-factor settings
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L22
- * @version 47
+ * @version 48
  */
 
 export function adjustAnimationTime(msecs: number, params?: AdjustAnimationTimeParams): number;
@@ -34,14 +34,14 @@ export function adjustAnimationTime(msecs: number, params?: AdjustAnimationTimeP
  * @param actor - the actor
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L40
- * @version 47
+ * @version 48
  */
 
 export function ensureActorVisibleInScrollView(scrollView: St.ScrollView, actor: Clutter.Actor): void;
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L90
- * @version 47
+ * @version 48
  */
 export interface WiggleParams {
     /** The offset to move the actor by per-wiggle */
@@ -60,7 +60,7 @@ export interface WiggleParams {
  * @param params options for the animation
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/animationUtils.js#L86
- * @version 47
+ * @version 48
  */
 
 export function wiggle(actor: Clutter.Actor, params: WiggleParams): void;

--- a/packages/gnome-shell/src/types/extension-metadata.ts
+++ b/packages/gnome-shell/src/types/extension-metadata.ts
@@ -4,8 +4,8 @@ import type Gio from '@girs/gio-2.0';
 
 /** The Metadata Object for Extensions
  *
- * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js#L48
- * @version 47
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js#L49
+ * @version 48
  */
 export interface ExtensionMetadata {
     readonly uuid: string;

--- a/packages/gnome-shell/src/ui/calendar.d.ts
+++ b/packages/gnome-shell/src/ui/calendar.d.ts
@@ -5,10 +5,8 @@ import type Gio from '@girs/gio-2.0';
 import type St from '@girs/st-16';
 import type Clutter from '@girs/clutter-16';
 
-import type { Message, MessageListSection } from './messageList.js';
-import type { Notification, MessageTray, Source } from './messageTray.js';
 import type { Switch } from './popupMenu.js';
-import type { MediaSection } from './mpris.js';
+import type { MessageView } from './messageList.js';
 
 declare function sameYear(dateA: Date, dateB: Date): boolean;
 
@@ -109,6 +107,10 @@ declare class DBusEventSource extends EventSourceBase {
     protected _getFilteredEvents(begin: Date, end: Date): Generator<CalendarEvent, void, unknown>;
 }
 
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/calendar.js#L406
+ * @version 48
+ */
 export class Calendar extends St.Widget {
     protected _weekStart: number;
     protected _settings: Gio.Settings;
@@ -162,43 +164,6 @@ export class Calendar extends St.Widget {
     protected _update(): void;
 }
 
-export class NotificationMessage extends Message {
-    /** @hidden */
-    override _init(params?: Partial<St.Button.ConstructorProps>): void;
-    /** @hidden */
-    override _init(title: string, body: string): void;
-    public _init(notification: Notification): void;
-
-    public vfunc_clicked(): void;
-    public canClose(): boolean;
-
-    protected _getIcon(): St.Icon;
-    protected _onUpdated(n: Notification, _clear?: boolean): void;
-}
-
-declare class TimeLabel extends St.Label {
-    _datetime: Date;
-
-    /** @hidden */
-    public _init(params?: Partial<St.Label.ConstructorProps>): void;
-    public _init(datetime: Date): void;
-
-    public vfunc_map(): void;
-}
-
-declare class NotificationSection extends MessageListSection {
-    public readonly allowed: boolean;
-
-    /** @hidden */
-    public _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
-    public _init(): void;
-
-    public vfunc_map(): void;
-
-    protected _sourceAdded(tray: MessageTray, source: Source): void;
-    protected _onNotificationAdded(source: Source, notification: Notification): void;
-}
-
 declare class Placeholder extends St.BoxLayout {
     protected _date: Date;
     protected _icon: St.Icon;
@@ -220,15 +185,18 @@ declare class DoNotDisturbSwitch extends Switch {
     public _init(): void;
 }
 
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/calendar.js#L799
+ * @version 48
+ */
+
 export class CalendarMessageList extends St.Widget {
     _placeholder: Placeholder;
     _scrollView: St.ScrollView;
     _dndSwitch: DoNotDisturbSwitch;
     _dndButton: St.Button;
     _clearButton: St.Button;
-    _sectionList: St.BoxLayout;
-    _mediaSection: MediaSection;
-    _notificationSection: NotificationSection;
+    _messageView: MessageView;
 
     // visible: boolean;
 
@@ -236,6 +204,5 @@ export class CalendarMessageList extends St.Widget {
     override _init(config?: Partial<St.Widget.ConstructorProps>): void;
     public _init(): void;
 
-    protected _addSection(section: MessageListSection): void;
-    protected _sync(): void;
+    maybeCollapseMessageGroupForEvent(event: Clutter.Event): boolean;
 }

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -5,7 +5,7 @@ import type St from '@girs/st-16';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L113
- * @version 47
+ * @version 48
  */
 export interface ButtonInfo {
     action: () => void;
@@ -17,7 +17,7 @@ export interface ButtonInfo {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L18
- * @version 47
+ * @version 48
  */
 export class Dialog extends St.Widget {
     protected _parentActor: St.Widget;
@@ -41,7 +41,7 @@ export class Dialog extends St.Widget {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L158
- * @version 47
+ * @version 48
  */
 export namespace MessageDialogContent {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
@@ -51,7 +51,7 @@ export namespace MessageDialogContent {
 }
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L171
- * @version 47
+ * @version 48
  */
 export class MessageDialogContent extends St.BoxLayout {
     public title: string;
@@ -66,7 +66,7 @@ export class MessageDialogContent extends St.BoxLayout {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L250
- * @version 47
+ * @version 48
  */
 export namespace ListSection {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
@@ -76,7 +76,7 @@ export namespace ListSection {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L258
- * @version 47
+ * @version 48
  */
 export class ListSection extends St.BoxLayout {
     protected _listScrollView: St.ScrollView;
@@ -91,7 +91,7 @@ export class ListSection extends St.BoxLayout {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L294
- * @version 47
+ * @version 48
  */
 export namespace ListSectionItem {
     export interface ConstructorProps extends St.BoxLayout.ConstructorProps {
@@ -103,7 +103,7 @@ export namespace ListSectionItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/dialog.js#L311
- * @version 47
+ * @version 48
  */
 export class ListSectionItem extends St.BoxLayout {
     protected _iconActorBin: St.Bin;

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -17,7 +17,7 @@ import type { BackgroundManager } from './background.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L159
- * @version 47
+ * @version 48
  */
 export interface Geometry {
     x: number;
@@ -27,7 +27,7 @@ export interface Geometry {
 }
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L41
- * @version 47
+ * @version 48
  */
 
 export namespace MonitorConstraint {
@@ -40,7 +40,7 @@ export namespace MonitorConstraint {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L56
- * @version 47
+ * @version 48
  */
 export class MonitorConstraint extends Clutter.Constraint {
     protected _primary: boolean;
@@ -63,7 +63,7 @@ export class MonitorConstraint extends Clutter.Constraint {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L158
- * @version 47
+ * @version 48
  */
 declare class Monitor {
     public index: number;
@@ -79,7 +79,7 @@ declare class Monitor {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L174
- * @version 47
+ * @version 48
  */
 declare class UiActor extends St.Widget {
     public constructor(props?: Partial<St.Widget.ConstructorProps>);
@@ -91,7 +91,7 @@ declare class UiActor extends St.Widget {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L1454
- * @version 47
+ * @version 48
  */
 declare class ScreenTransition extends Clutter.Actor {
     constructor();
@@ -109,7 +109,7 @@ declare class ScreenTransition extends Clutter.Actor {
  * overview.
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L1141
- * @version 47
+ * @version 48
  */
 declare class HotCorner extends Clutter.Actor {
     protected _entered: boolean;
@@ -137,7 +137,7 @@ declare class HotCorner extends Clutter.Actor {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L186
- * @version 47
+ * @version 48
  */
 export interface TrackedActors {
     trackFullscreen: boolean;
@@ -147,7 +147,7 @@ export interface TrackedActors {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L192
- * @version 47
+ * @version 48
  */
 export class LayoutManager extends GObject.Object {
     protected _rtl: boolean;
@@ -323,7 +323,7 @@ export class LayoutManager extends GObject.Object {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/layout.js#L1309
- * @version 47
+ * @version 48
  */
 declare class PressureBarrier extends EventEmitter {
     protected _threshold: number;

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -6,7 +6,7 @@ import type Shell from '@girs/shell-16';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L10
- * @version 47
+ * @version 48
  */
 export const DEFAULT_FADE_FACTOR = 0.4;
 export const VIGNETTE_BRIGHTNESS = 0.5;
@@ -14,7 +14,7 @@ export const VIGNETTE_SHARPNESS = 0.7;
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L31
- * @version 47
+ * @version 48
  */
 export namespace RadialShaderEffect {
     export interface ConstructorProps extends Shell.GLSLEffect.ConstructorProps {
@@ -25,7 +25,7 @@ export namespace RadialShaderEffect {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L42
- * @version 47
+ * @version 48
  */
 export class RadialShaderEffect extends Shell.GLSLEffect {
     protected _brightness: number;
@@ -42,7 +42,7 @@ export class RadialShaderEffect extends Shell.GLSLEffect {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L121
- * @version 47
+ * @version 48
  */
 export interface LightboxAdditionalParameters {
     inhibitEvents?: boolean;
@@ -52,7 +52,7 @@ export interface LightboxAdditionalParameters {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L91
- * @version 47
+ * @version 48
  */
 export namespace Lightbox {
     export interface ConstructorProps extends St.Bin.ConstructorProps, LightboxAdditionalParameters {
@@ -63,7 +63,7 @@ export namespace Lightbox {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/lightbox.js#L96
- * @version 47
+ * @version 48
  */
 export class Lightbox extends St.Bin {
     protected _active: boolean;

--- a/packages/gnome-shell/src/ui/main.d.ts
+++ b/packages/gnome-shell/src/ui/main.d.ts
@@ -9,6 +9,7 @@ import type Meta from '@girs/meta-16';
 import { ComponentManager } from './components.js';
 import { AccessDialogDBus } from './accessDialog.js';
 import { AudioDeviceSelectionDBus } from './audioDeviceSelection.js';
+// import * as BreakManager from '../misc/breakManager.js';
 // import * as CtrlAltTab from './ctrlAltTab.js';
 // import * as EndSessionDialog from './endSessionDialog.js';
 import { ExtensionManager } from './extensionSystem.js';
@@ -38,6 +39,7 @@ import { NotificationDaemon } from './notificationDaemon.js';
 // import * as SessionMode from './sessionMode.js';
 // import * as ShellDBus from './shellDBus.js';
 // import * as ShellMountOperation from './shellMountOperation.js';
+// import * as TimeLimitsManager from '../misc/timeLimitsManager.js';
 import { WindowManager } from './windowManager.js';
 // import * as Magnifier from './magnifier.js';
 // import * as XdndHandler from './xdndHandler.js';
@@ -99,6 +101,8 @@ export declare const modalCount: any;
 export declare const actionMode: Shell.ActionMode.NONE;
 
 export declare const modalActorFocusStack: any[];
+
+export declare const screenTimeDBus: any;
 
 /**
  * @deprecated use layoutManager.uiGroup instead

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -5,9 +5,12 @@ import type Gio from '@girs/gio-2.0';
 import type GLib from '@girs/glib-2.0';
 import type St from '@girs/st-16';
 import type Clutter from '@girs/clutter-16';
+import type { Notification } from './messageTray';
+import type { MprisPlayer, MprisSource } from './mpris';
 
 /**
- * @version 46
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageList.js#L33
+ * @version 48
  */
 export class URLHighlighter extends St.Label {
     constructor(text?: string, lineWrap?: boolean, allowMarkup?: boolean);
@@ -26,6 +29,36 @@ export class URLHighlighter extends St.Label {
     protected _findUrlAtPos(event: Clutter.Event): [number, number];
 }
 
+declare class ScaleLayout extends Clutter.BinLayout {
+    _container: Clutter.Actor | null;
+    _scalingEnabled: boolean;
+
+    get scalingEnabled(): boolean;
+
+    set scalingEnabled(value: boolean);
+
+    vfunc_set_container(container: Clutter.Actor | null): void;
+
+    vfunc_get_preferred_width(container: Clutter.Actor, forHeight: number): [number, number];
+
+    vfunc_get_preferred_height(container: Clutter.Actor, forWidth: number): [number, number];
+}
+
+declare class LabelExpanderLayout extends Clutter.BinLayout {
+    _expansion: number;
+    _expandLines: number;
+
+    constructor(params: Clutter.BinLayout.ConstructorProps);
+
+    get expansion(): number;
+
+    set expansion(v: number);
+
+    set expandLines(v: number);
+
+    vfunc_get_preferred_height(container: Clutter.Actor, forWidth: number): [number, number];
+}
+
 export declare namespace Source {
     interface ObjectProperties {
         title: string;
@@ -37,7 +70,8 @@ export declare namespace Source {
 }
 
 /**
- * @version 46
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageList.js#L284
+ * @version 48
  */
 export class Source extends GObject.Object implements Source.ObjectProperties {
     constructor(params?: Source.ConstructorProps);
@@ -50,8 +84,27 @@ export class Source extends GObject.Object implements Source.ObjectProperties {
     public set iconName(iconName: string);
 }
 
+declare class TimeLabel extends St.Label {
+    _datetime: Date;
+
+    /** @hidden */
+    public _init(params?: Partial<St.Label.ConstructorProps>): void;
+    public _init(datetime: Date): void;
+
+    get datetime(): Date;
+
+    set datetime(datetime: Date);
+
+    public vfunc_map(): void;
+}
+
+declare class MessageHeader extends St.BoxLayout {
+    constructor(source: Source);
+}
+
 /**
- * @version 46
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageList.js#L421
+ * @version 48
  */
 export class Message extends St.Button {
     constructor(source: Source);
@@ -77,30 +130,180 @@ export class Message extends St.Button {
     public canClose(): boolean;
 
     public vfunc_key_press_event(keyEvent: Clutter.KeyEvent): boolean;
-
-    protected _onDestroy(): void;
 }
 
 /**
- * @version 46
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageList.js#L691
+ * @version 48
  */
-export class MessageListSection extends St.BoxLayout {
-    public readonly canClear: boolean;
-    public readonly empty: boolean;
+export class NotificationMessage extends Message {
+    /** @hidden */
+    override _init(params?: Partial<St.Button.ConstructorProps>): void;
+    /** @hidden */
+    override _init(title: string, body: string): void;
+    public _init(notification: Notification): void;
 
-    public readonly allowed: boolean;
+    public vfunc_clicked(): void;
+    public canClose(): boolean;
 
-    constructor();
+    protected _getIcon(): St.Icon;
+    protected _onUpdated(n: Notification, _clear?: boolean): void;
+}
 
-    public addMessage(message: Message, animate?: boolean): void;
+declare class MediaMessage extends Message {
+    protected _player: MprisPlayer;
+    protected _icon: St.Icon;
+    protected _secondaryBin: St.Bin;
+    protected _closeButton: St.Button;
+    protected _prevButton: St.Button;
+    protected _playPauseButton: St.Button;
+    protected _nextButton: St.Button;
 
-    public addMessageAtIndex(message: Message, index: number, animate?: boolean): void;
+    constructor(player: MprisPlayer);
 
-    public moveMessage(message: Message, newIndex: number, animate?: boolean): void;
+    /** @hidden */
+    public override _init(params?: Partial<St.Button.ConstructorProps>): void;
+    /** @hidden */
+    public override _init(title: string, body: string): void;
+    public _init(player: MprisPlayer): void;
 
-    public removeMessage(message: Message, animate?: boolean): void;
+    public vfunc_clicked(): void;
 
-    public clear(): void;
+    protected _updateNavButton(button: St.Button, sensitive?: boolean): void;
+    protected _update(): void;
+}
 
-    protected _onKeyFocusIn(messageActor: St.Widget): void;
+declare class NotificationMessageGroup extends St.Widget {
+    source: Source;
+    _expanded: boolean;
+    _nUrgent: number;
+    _focusChild: null | Clutter.Actor;
+
+    constructor(source: Source);
+
+    get expanded(): boolean;
+
+    get hasUrgent(): boolean;
+
+    _onKeyFocusIn(actor: Clutter.Actor): void;
+
+    get focusChild(): null | Clutter.Actor;
+
+    expand(): Promise<void>;
+
+    collapse(): Promise<void>;
+
+    get expandedHeight(): number;
+
+    _ensureCoverPosition(): void;
+
+    _updateStackedMessagesFade(): void;
+
+    canClose(): boolean;
+
+    _addNotification(notification: Notification): void;
+
+    _removeNotification(notification: Notification): void;
+
+    vfunc_paint(paintContext: Clutter.PaintContext): void;
+
+    vfunc_pick(pickContext: Clutter.PickContext): void;
+
+    vfunc_map(): void;
+
+    vfunc_get_focus_chain(): Clutter.Actor[];
+
+    _moveMessage(message: Message, index: number): void;
+
+    close(): void;
+}
+
+declare class MessageGroupExpanderLayout extends Clutter.LayoutManager {
+    _expansion: number;
+
+    constructor(cover: Clutter.Actor, header: MessageHeader);
+
+    get expansion(): number;
+
+    set expansion(v: number);
+
+    getExpandedHeight(container: Clutter.Actor, forWidth: number): [number, number];
+
+    vfunc_get_preferred_width(container: Clutter.Actor, forHeight: number): [number, number];
+
+    vfunc_get_preferred_height(container: Clutter.Actor, forWidth: number): [number, number];
+
+    vfunc_allocate(container: Clutter.Actor, box: Clutter.ActorBox): void;
+}
+declare class MessageViewLayout extends Clutter.LayoutManager {
+    constructor(overlay: Clutter.Actor);
+
+    vfunc_get_preferred_width(container: Clutter.Actor, forHeight: number): [number, number];
+
+    vfunc_get_preferred_height(container: Clutter.Actor, forWidth: number): [number, number];
+
+    vfunc_allocate(container: Clutter.Actor, box: Clutter.ActorBox): void;
+}
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageList.js#L1391
+ * @version 48
+ */
+export class MessageView extends St.Viewport {
+    messages: Message[];
+
+    _nUrgent: number;
+    _mediaSource: MprisSource;
+    _overlay: Clutter.Actor;
+    _expandedGroup: NotificationMessageGroup | null;
+
+    get empty(): boolean;
+
+    get canClear(): boolean;
+
+    _onKeyFocusIn(messageActor: Clutter.Actor): void;
+
+    vfunc_get_focus_chain(): Clutter.Actor[];
+
+    _addMessageAtIndex(message: Message, index: number): void;
+
+    _moveMessage(message: Message, index: number): void;
+
+    _removeMessage(message: Message): void;
+
+    clear(): void;
+
+    // When a group is expanded the user isn't allowed to scroll outside the expanded group,
+    // therefore the adjustment used by the MessageView needs to be different then the external
+    // adjustment used by the scrollbar and scrollview.
+    vfunc_set_adjustments(hadjustment: St.Adjustment, vadjustment: St.Adjustment): void;
+
+    vfunc_allocate(box: Clutter.ActorBox): void;
+
+    vfunc_style_changed(): void;
+
+    _setupMpris(): void;
+
+    _addPlayer(player: MprisPlayer): void;
+
+    _removePlayer(player: MprisPlayer): void;
+
+    _setupNotifications(): void;
+
+    _addNotificationSource(source: Source): void;
+
+    _removeNotificationSource(source: Source): void;
+
+    // Try to center the expanded group in the available space
+    _scrollToExpandedGroup(): void;
+
+    get expandedGroup(): NotificationMessageGroup | null;
+
+    _setExpandedGroup(group: NotificationMessageGroup | null): Promise<void>;
+
+    collapse(): void;
+
+    _highlightGroup(group: NotificationMessageGroup): void;
+
+    _unhighlightGroup(): void;
 }

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -31,11 +31,7 @@ export class URLHighlighter extends St.Label {
 
 declare class ScaleLayout extends Clutter.BinLayout {
     _container: Clutter.Actor | null;
-    _scalingEnabled: boolean;
-
-    get scalingEnabled(): boolean;
-
-    set scalingEnabled(value: boolean);
+    scalingEnabled: boolean;
 
     vfunc_set_container(container: Clutter.Actor | null): void;
 
@@ -45,14 +41,10 @@ declare class ScaleLayout extends Clutter.BinLayout {
 }
 
 declare class LabelExpanderLayout extends Clutter.BinLayout {
-    _expansion: number;
+    expansion: number;
     _expandLines: number;
 
     constructor(params: Clutter.BinLayout.ConstructorProps);
-
-    get expansion(): number;
-
-    set expansion(v: number);
 
     set expandLines(v: number);
 
@@ -85,15 +77,11 @@ export class Source extends GObject.Object implements Source.ObjectProperties {
 }
 
 declare class TimeLabel extends St.Label {
-    _datetime: Date;
+    datetime: Date;
 
     /** @hidden */
     public _init(params?: Partial<St.Label.ConstructorProps>): void;
     public _init(datetime: Date): void;
-
-    get datetime(): Date;
-
-    set datetime(datetime: Date);
 
     public vfunc_map(): void;
 }
@@ -219,13 +207,9 @@ declare class NotificationMessageGroup extends St.Widget {
 }
 
 declare class MessageGroupExpanderLayout extends Clutter.LayoutManager {
-    _expansion: number;
+    expansion: number;
 
     constructor(cover: Clutter.Actor, header: MessageHeader);
-
-    get expansion(): number;
-
-    set expansion(v: number);
 
     getExpandedHeight(container: Clutter.Actor, forWidth: number): [number, number];
 

--- a/packages/gnome-shell/src/ui/messageTray.d.ts
+++ b/packages/gnome-shell/src/ui/messageTray.d.ts
@@ -13,13 +13,13 @@ import type * as MessageList from './messageList.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L20
- * @version 47
+ * @version 48
  */
 export const ANIMATION_TIME: number;
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L36
- * @version 47
+ * @version 48
  */
 export enum State {
     HIDDEN = 0,
@@ -38,7 +38,7 @@ export enum State {
  * newer version having replaced them.
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L51
- * @version 47
+ * @version 48
  */
 export enum NotificationDestroyedReason {
     EXPIRED = 1,
@@ -54,7 +54,7 @@ export enum NotificationDestroyedReason {
  * through the Telepathy client.
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L62
- * @version 47
+ * @version 48
  */
 export enum Urgency {
     LOW = 0,
@@ -72,7 +72,7 @@ export enum Urgency {
  * of a notification is shown on the lock screen.
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L76
- * @version 47
+ * @version 48
  */
 export enum PrivacyScope {
     USER = 0,
@@ -86,7 +86,7 @@ export enum PrivacyScope {
  * A notification without a policy object will inherit the default one.
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L160
- * @version 47
+ * @version 48
  */
 export abstract class NotificationPolicy extends GObject.Object {
     readonly enable: boolean;
@@ -109,7 +109,7 @@ export abstract class NotificationPolicy extends GObject.Object {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L213
- * @version 47
+ * @version 48
  */
 export class NotificationGenericPolicy extends NotificationPolicy {
     public id: string;
@@ -126,7 +126,7 @@ export class NotificationGenericPolicy extends NotificationPolicy {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L243
- * @version 47
+ * @version 48
  */
 export class NotificationApplicationPolicy extends NotificationPolicy {
     public id: string;
@@ -147,7 +147,7 @@ export class NotificationApplicationPolicy extends NotificationPolicy {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L316
- * @version 47
+ * @version 48
  */
 export class Sound extends GObject.Object {
     constructor(file: Gio.File | null | undefined, themedName?: string);
@@ -157,7 +157,7 @@ export class Sound extends GObject.Object {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L335
- * @version 47
+ * @version 48
  */
 export class Action extends GObject.Object {
     constructor(label: string, callback: () => void);
@@ -169,7 +169,7 @@ export class Action extends GObject.Object {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L482
- * @version 47
+ * @version 48
  */
 export declare namespace Source {
     export interface ConstructorProps extends MessageList.Source.ConstructorProps {
@@ -179,7 +179,7 @@ export declare namespace Source {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L499
- * @version 47
+ * @version 48
  */
 export class Source extends MessageList.Source {
     constructor(params?: Partial<Source.ConstructorProps>);
@@ -228,7 +228,7 @@ export class Source extends MessageList.Source {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L604
- * @version 47
+ * @version 48
  */
 export declare namespace Notification {
     export interface ObjectProperties {
@@ -253,7 +253,7 @@ export declare namespace Notification {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L352
- * @version 47
+ * @version 48
  */
 export class Notification extends GObject.Object implements Notification.ObjectProperties {
     constructor(params?: Notification.ConstructorProps);
@@ -284,7 +284,9 @@ export class Notification extends GObject.Object implements Notification.ObjectP
      * @param label the label for the action's button
      * @param callback the callback for the action
      */
-    addAction(label: string, callback: () => void): void;
+    addAction(label: string, callback: () => void): Action;
+
+    removeAction(action: Action): void;
 
     clearActions(): void;
 
@@ -316,7 +318,7 @@ export class Notification extends GObject.Object implements Notification.ObjectP
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L676
- * @version 47
+ * @version 48
  */
 export class MessageTray extends St.Widget {
     constructor();
@@ -392,6 +394,6 @@ export class MessageTray extends St.Widget {
  * The {Source} that should be used to send system notifications.
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageTray.js#L1290
- * @version 47
+ * @version 48
  */
 export function getSystemSource(): Source;

--- a/packages/gnome-shell/src/ui/mpris.d.ts
+++ b/packages/gnome-shell/src/ui/mpris.d.ts
@@ -4,30 +4,7 @@ import type Gio from '@girs/gio-2.0';
 import type St from '@girs/st-16';
 
 import type { EventEmitter } from '../misc/signals.js';
-import type { Message, MessageListSection } from './messageList.js';
-
-declare class MediaMessage extends Message {
-    protected _player: MprisPlayer;
-    protected _icon: St.Icon;
-    protected _secondaryBin: St.Bin;
-    protected _closeButton: St.Button;
-    protected _prevButton: St.Button;
-    protected _playPauseButton: St.Button;
-    protected _nextButton: St.Button;
-
-    constructor(player: MprisPlayer);
-
-    /** @hidden */
-    public override _init(params?: Partial<St.Button.ConstructorProps>): void;
-    /** @hidden */
-    public override _init(title: string, body: string): void;
-    public _init(player: MprisPlayer): void;
-
-    public vfunc_clicked(): void;
-
-    protected _updateNavButton(button: St.Button, sensitive?: boolean): void;
-    protected _update(): void;
-}
+import type { NotificationMessageGroup } from './messageList.js';
 
 declare class MprisPlayer extends EventEmitter {
     readonly status: string;
@@ -50,7 +27,7 @@ declare class MprisPlayer extends EventEmitter {
     _updateState(): void;
 }
 
-export class MediaSection extends MessageListSection {
+export class MprisSource extends NotificationMessageGroup {
     _players: Map<string, MprisPlayer>;
     _proxy: Gio.DBusProxy;
 

--- a/packages/gnome-shell/src/ui/panelMenu.d.ts
+++ b/packages/gnome-shell/src/ui/panelMenu.d.ts
@@ -7,7 +7,7 @@ import type { PopupMenu, PopupDummyMenu } from './popupMenu.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L11
- * @version 47
+ * @version 48
  */
 declare namespace ButtonBox {
     interface ConstructorProps extends St.Widget.ConstructorProps {}
@@ -15,7 +15,7 @@ declare namespace ButtonBox {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L12
- * @version 47
+ * @version 48
  */
 declare class ButtonBox extends St.Widget {
     constructor(params?: Partial<ButtonBox.ConstructorProps>);
@@ -31,7 +31,7 @@ declare class ButtonBox extends St.Widget {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L95
- * @version 47
+ * @version 48
  */
 export namespace Button {
     interface ConstructorProps extends ButtonBox.ConstructorProps {}
@@ -39,7 +39,7 @@ export namespace Button {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js#L97
- * @version 47
+ * @version 48
  */
 export class Button extends ButtonBox {
     menu: PopupMenu | PopupDummyMenu;

--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -10,7 +10,7 @@ import * as BoxPointer from './boxpointer.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L16
- * @version 47
+ * @version 48
  */
 export enum Ornament {
     NONE = 0,
@@ -22,13 +22,13 @@ export enum Ornament {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L39
- * @version 47
+ * @version 48
  */
 export function arrowIcon(side: St.Side): St.Icon;
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L67
- * @version 47
+ * @version 48
  */
 declare namespace PopupBaseMenuItem {
     export interface ConstructorProps {
@@ -42,7 +42,7 @@ declare namespace PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L81
- * @version 47
+ * @version 48
  */
 declare class PopupBaseMenuItem extends St.BoxLayout {
     readonly actor: PopupBaseMenuItem;
@@ -72,7 +72,7 @@ declare class PopupBaseMenuItem extends St.BoxLayout {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L285
- * @version 47
+ * @version 48
  */
 export namespace PopupMenuItem {
     export interface ConstructorProps extends PopupBaseMenuItem.ConstructorProps {}
@@ -80,7 +80,7 @@ export namespace PopupMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L286
- * @version 47
+ * @version 48
  */
 export class PopupMenuItem extends PopupBaseMenuItem {
     constructor(text: string, params?: Partial<PopupMenuItem.ConstructorProps>);
@@ -93,7 +93,7 @@ export class PopupMenuItem extends PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L302
- * @version 47
+ * @version 48
  */
 export class PopupSeparatorMenuItem extends PopupBaseMenuItem {
     constructor(text?: string);
@@ -106,7 +106,7 @@ export class PopupSeparatorMenuItem extends PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L330
- * @version 47
+ * @version 48
  */
 export namespace Switch {
     export interface ConstructorProps extends St.Bin.ConstructorProps {
@@ -116,7 +116,7 @@ export namespace Switch {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L337
- * @version 47
+ * @version 48
  */
 export class Switch extends St.Widget {
     state: boolean;
@@ -143,18 +143,20 @@ export class Switch extends St.Widget {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L415
- * @version 47
+ * @version 48
  */
 export namespace PopupSwitchMenuItem {
-    export interface ConstructorProps extends PopupBaseMenuItem.ConstructorProps {}
+    export interface ConstructorProps extends PopupBaseMenuItem.ConstructorProps {
+        state: boolean;
+    }
 }
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L417
- * @version 47
+ * @version 48
  */
 export class PopupSwitchMenuItem extends PopupBaseMenuItem {
-    readonly state: boolean;
+    state: boolean;
 
     constructor(text: string, active: boolean, params?: PopupSwitchMenuItem.ConstructorProps);
     /** @hidden Defined only to resolve type conflicts */
@@ -165,7 +167,7 @@ export class PopupSwitchMenuItem extends PopupBaseMenuItem {
     activate(event: Clutter.Event): void;
     toggle(): void;
     setToggleState(state: boolean): void;
-    checkAccessibleState(): void;
+    _checkAccessibleState(): void;
 
     // General signal handler methods
     connect(sigName: string, callback: (...args: any[]) => void): number;
@@ -180,7 +182,7 @@ export class PopupSwitchMenuItem extends PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L505
- * @version 47
+ * @version 48
  */
 export namespace PopupImageMenuItem {
     export interface ConstructorProps extends PopupBaseMenuItem.ConstructorProps {}
@@ -188,7 +190,7 @@ export namespace PopupImageMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L506
- * @version 47
+ * @version 48
  */
 export class PopupImageMenuItem extends PopupBaseMenuItem {
     constructor(text: string, icon: Gio.Icon | string, params?: PopupImageMenuItem.ConstructorProps);
@@ -201,7 +203,7 @@ export class PopupImageMenuItem extends PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L542
- * @version 47
+ * @version 48
  */
 export namespace PopupMenuBase {
     interface SignalMap {}
@@ -213,7 +215,7 @@ export namespace PopupMenuBase {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L542
- * @version 47
+ * @version 48
  */
 export class PopupMenuBase<S extends Signals.SignalMap<S> = PopupMenuBase.SignalMap> extends Signals.EventEmitter<S> {
     protected constructor(sourceActor: St.Widget, styleClass?: string);
@@ -243,7 +245,7 @@ export class PopupMenuBase<S extends Signals.SignalMap<S> = PopupMenuBase.Signal
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L871
- * @version 47
+ * @version 48
  */
 export namespace PopupMenu {
     interface SignalMap extends PopupMenuBase.SignalMap {}
@@ -251,7 +253,7 @@ export namespace PopupMenu {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L871
- * @version 47
+ * @version 48
  */
 export class PopupMenu<S extends Signals.SignalMap<S> = PopupMenu.SignalMap> extends PopupMenuBase<S> {
     constructor(sourceActor: St.Widget, arrowAlignment: number, arrowSide: St.Side);
@@ -266,7 +268,7 @@ export class PopupMenu<S extends Signals.SignalMap<S> = PopupMenu.SignalMap> ext
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1015
- * @version 47
+ * @version 48
  */
 export class PopupDummyMenu extends Signals.EventEmitter {
     constructor(sourceActor: St.Widget);
@@ -283,7 +285,7 @@ export class PopupDummyMenu extends Signals.EventEmitter {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1053
- * @version 47
+ * @version 48
  */
 export namespace PopupSubMenu {
     interface SignalMap extends PopupMenuBase.SignalMap {}
@@ -291,7 +293,7 @@ export namespace PopupSubMenu {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1053
- * @version 47
+ * @version 48
  */
 export class PopupSubMenu<S extends Signals.SignalMap<S> = PopupSubMenu.SignalMap> extends PopupMenuBase<S> {
     actor: St.ScrollView;
@@ -307,7 +309,7 @@ export class PopupSubMenu<S extends Signals.SignalMap<S> = PopupSubMenu.SignalMa
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1192
- * @version 47
+ * @version 48
  */
 export namespace PopupMenuSection {
     interface SignalMap extends PopupMenuBase.SignalMap {}
@@ -322,7 +324,7 @@ export namespace PopupMenuSection {
  * to the user
  *
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1192
- * @version 47
+ * @version 48
  */
 export class PopupMenuSection<S extends Signals.SignalMap<S> = PopupMenuSection.SignalMap> extends PopupMenuBase<S> {
     constructor();
@@ -335,7 +337,7 @@ export class PopupMenuSection<S extends Signals.SignalMap<S> = PopupMenuSection.
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1215
- * @version 47
+ * @version 48
  */
 export class PopupSubMenuMenuItem extends PopupBaseMenuItem {
     readonly menu: PopupSubMenu;
@@ -354,7 +356,7 @@ export class PopupSubMenuMenuItem extends PopupBaseMenuItem {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1321
- * @version 47
+ * @version 48
  */
 export namespace PopupMenuManager {
     export interface ConstructorProps {
@@ -364,7 +366,7 @@ export namespace PopupMenuManager {
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/popupMenu.js#L1321
- * @version 47
+ * @version 48
  */
 export class PopupMenuManager {
     constructor(owner: Clutter.Actor, grabParams?: PopupMenuManager.ConstructorProps);

--- a/packages/gnome-shell/src/ui/windowManager.d.ts
+++ b/packages/gnome-shell/src/ui/windowManager.d.ts
@@ -1,10 +1,58 @@
+// https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/windowManager.js
+
 import type Clutter from 'gi://Clutter';
 import type Gio from 'gi://Gio';
 import type Meta from 'gi://Meta';
 import type Shell from 'gi://Shell';
+import type St from '@girs/st-16';
+import type Mtk from '@girs/mtk-16';
+import type { Monitor } from './layout';
+import type { Workspace } from './workspace';
 
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/windowManager.js#L28
+ * @version 48
+ */
+export const SHELL_KEYBINDINGS_SCHEMA: string;
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/windowManager.js#L134
+ * @version 48
+ */
+export class WindowDimmer extends Clutter.BrightnessContrastEffect {
+    _init(): void;
+
+    _syncEnabled(dimmed: boolean): void;
+
+    setDimmed(dimmed: boolean, animate: boolean): void;
+}
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/windowManager.js#L394
+ * @version 48
+ */
+export class TilePreview extends St.Widget {
+    _init(): void;
+
+    open(window: Meta.Window, tileRect: Mtk.Rectangle, monitorIndex: number): void;
+
+    close(): void;
+
+    _reset(): void;
+
+    _updateStyle(monitor: Monitor): void;
+}
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/windowManager.js#L508
+ * @version 48
+ */
 export class WindowManager {
     insertWorkspace(pos: number): void;
+
+    keepWorkspaceAlive(workspace: Workspace, duration: number): void;
+
+    skipNextEffect(actor: Clutter.Actor): void;
 
     setCustomKeybindingHandler(name: string, modes: Shell.ActionMode, handler: Meta.KeyHandlerFunc): void;
 
@@ -13,6 +61,10 @@ export class WindowManager {
     removeKeybinding(name: string): void;
 
     allowKeybinding(name: string, modes: Shell.ActionMode): void;
+
+    actionMoveWorkspace(workspace: Workspace): void;
+
+    actionMoveWindow(window: Meta.Window, workspace: Workspace): void;
 
     handleWorkspaceScroll(event: Clutter.Event): boolean;
 }


### PR DESCRIPTION
This PR does two things:

Implement most of the types from the changes described in porting guide [here](https://gjs.guide/extensions/upgrading/gnome-shell-48.html)

check all types I use in my extension, similar to #53 
