### PR TITLE
Hotfix: relative import paths require .js suffix

### DIFF
--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gjsify/gnome-shell-hello-world-example",
-  "version": "48.0.0",
+  "version": "48.0.1",
   "description": "Simple Gnome Shell Hello World Extension example",
   "type": "module",
   "main": "dist/extension.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gnome-shell",
-    "version": "48.0.0",
+    "version": "48.0.1",
     "description": "GJS TypeScript type definitions for GNOME Shell Extensions",
     "main": "src/index.js",
     "type": "module",

--- a/packages/gnome-shell/package.json
+++ b/packages/gnome-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girs/gnome-shell",
-  "version": "48.0.0",
+  "version": "48.0.1",
   "description": "GJS TypeScript type definitions for GNOME Shell Extensions",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -5,8 +5,8 @@ import type Gio from '@girs/gio-2.0';
 import type GLib from '@girs/glib-2.0';
 import type St from '@girs/st-16';
 import type Clutter from '@girs/clutter-16';
-import type { Notification } from './messageTray';
-import type { MprisPlayer, MprisSource } from './mpris';
+import type { Notification } from './messageTray.js';
+import type { MprisPlayer, MprisSource } from './mpris.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/messageList.js#L33

--- a/packages/gnome-shell/src/ui/windowManager.d.ts
+++ b/packages/gnome-shell/src/ui/windowManager.d.ts
@@ -6,8 +6,8 @@ import type Meta from 'gi://Meta';
 import type Shell from 'gi://Shell';
 import type St from '@girs/st-16';
 import type Mtk from '@girs/mtk-16';
-import type { Monitor } from './layout';
-import type { Workspace } from './workspace';
+import type { Monitor } from './layout.js';
+import type { Workspace } from './workspace.js';
 
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/windowManager.js#L28


### PR DESCRIPTION
Same issue as in #45

I've already released this a hotfix (48.0.1) to the NPM registry, so I am going to merge this PR immediately too.