### PR TITLE
Fix: Export the Console Interface as `ConsoleLike`

### DIFF
--- a/examples/hello-world/src/extension.ts
+++ b/examples/hello-world/src/extension.ts
@@ -2,12 +2,13 @@ import '@girs/gjs'; // For global types like `log()`
 import St from '@girs/st-16';
 
 import '@girs/gnome-shell/extensions/global'; // For global shell types
-import { Extension, gettext as _ } from '@girs/gnome-shell/extensions/extension';
+import { Extension, gettext as _, type ConsoleLike } from '@girs/gnome-shell/extensions/extension';
 import PanelMenu from '@girs/gnome-shell/ui/panelMenu';
 import * as Main from '@girs/gnome-shell/ui/main';
 
 export default class ExampleExtension extends Extension {
     private _indicator: PanelMenu.Button | null = null;
+    private _console: ConsoleLike | null = null;
 
     override enable() {
         if (this._indicator !== null) {
@@ -26,10 +27,14 @@ export default class ExampleExtension extends Extension {
 
         // Add the indicator to the panel
         Main.panel.addToStatusArea(this.uuid, this._indicator);
+
+        this._console = this.getLogger();
+        this._console?.log('Hello from the example extension');
     }
 
     override disable() {
         this._indicator?.destroy();
         this._indicator = null;
+        this._console = null;
     }
 }

--- a/packages/gnome-shell/src/extensions/extension.d.ts
+++ b/packages/gnome-shell/src/extensions/extension.d.ts
@@ -1,4 +1,6 @@
 export type { ExtensionMetadata } from '../types/extension-metadata.js';
+
+export type { ConsoleLike } from './sharedInternals.js';
 import type { ExtensionBase, TranslationFunctions } from './sharedInternals.js';
 export class Extension extends ExtensionBase {
     static defineTranslationFunctions(url: string): TranslationFunctions;

--- a/packages/gnome-shell/src/extensions/sharedInternals.d.ts
+++ b/packages/gnome-shell/src/extensions/sharedInternals.d.ts
@@ -151,14 +151,10 @@ export class GettextWrapper {
 }
 
 /**
- * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js#L9
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/extensions/sharedInternals.js#L285
  * @version 48
  */
-declare class Console {
-    #extension: ExtensionBase;
-
-    constructor(ext: ExtensionBase);
-
+export interface ConsoleLike {
     log(...args: any[]): void;
 
     warn(...args: any[]): void;
@@ -176,4 +172,12 @@ declare class Console {
     group(...args: any[]): void;
 
     groupEnd(): void;
+}
+
+declare interface Console extends ConsoleLike {}
+
+declare class Console implements ConsoleLike {
+    #extension: ExtensionBase;
+
+    constructor(ext: ExtensionBase);
 }


### PR DESCRIPTION
See also https://github.com/gjsify/gnome-shell/pull/61#discussion_r2009115693


This is just a proposal on how to fix the problem from https://github.com/gjsify/gnome-shell/pull/61#discussion_r2009115693

Type duplication is bad, but to convert the class approach one to one, it has to be done. 

I don't think the class is necessary, as it is never really used as class, the constructor i not accessible, all members are private, so only member methods are usable, which make it, from a type perspective equal to an interface.


Edit: I found a way to avoid type duplication: see [here](https://stackoverflow.com/questions/65787571/avoiding-fields-declaration-duplication-in-interface-and-class-definition)
