### PR TITLE
Feat: Add release CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: CI
+name: Build CI
 
 on:
   push:
@@ -12,32 +9,39 @@ on:
       - "*"
 
 jobs:
-  ci:
-
-    runs-on: ubuntu-22.04
+  build:
+    name: Build CI with Node.js ${{ matrix.node-version }}
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
-        node-version: [18.x]
-        architecture:
-          - x64
+        node-version: [22.x]
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         submodules: true
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: yarn install
+
+    - name: Install dependencies
+      run: yarn install
+
     - name: Build Types
       run: yarn run build:types
+
     - name: Validate Formatting
       run: yarn run prettier:check
+
     - name: Validate Types
       run: NODE_OPTIONS=--max_old_space_size=9216 yarn run validate:types
+
     - name: Build Example
       run: yarn run build:example
+
     - name: Validate Example Typescript
       run: NODE_OPTIONS=--max_old_space_size=9216 yarn run validate:example

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release CI
+
+on:
+  release:
+    types: published
+
+env:
+  node-version: 22.x
+
+jobs:
+  release:
+    name: Release CI
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # This also setups a .npmrc file to publish to npm
+      - name: Use Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@girs'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Types
+        run: yarn run build:types
+
+      - name: Publish 
+        run: yarn run publish:${{github.event.release.prerelease && 'next' || 'latest'}} --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Add a release CI

This runs on every prerelease and release, and published the package automatically to npm, so we don't have to do that manually.


## WIP

- [ ] we need to have a repo secret `NPM_TOKEN` that can write to the npm registry and publish the package
- [ ] Use provenance workarounds, see https://github.com/yarnpkg/berry/issues/5430