### PR TITLE
Remove modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We are happy if you link your project through a PR here 😊
 **Every contribution, regardless of its size, is incredibly valuable.** If you're using these types and discover missing types necessary for your GNOME Shell Extension, contributing just those types is immensely helpful. This approach ensures the types are tested in real-world scenarios, vital for a project as extensive as the GNOME Shell.
 
 ### Getting Started:
-- To add TypeScript type definitions, mimic the data structure of the GNOME Shell's JavaScript source code. Private and protected methods and fields must not have visibility modifiers (making them implicitly public), and public ones must be marked as such.
+- To add TypeScript type definitions, mimic the data structure of the GNOME Shell's JavaScript source code. Visibility modifiers (`private`, `protected`, `public`) must not be included.
 - Contributions can range from adding a few types you need for your project to more extensive contributions.
 
 ### Development Instructions:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We are happy if you link your project through a PR here 😊
 **Every contribution, regardless of its size, is incredibly valuable.** If you're using these types and discover missing types necessary for your GNOME Shell Extension, contributing just those types is immensely helpful. This approach ensures the types are tested in real-world scenarios, vital for a project as extensive as the GNOME Shell.
 
 ### Getting Started:
-- To add TypeScript type definitions, mimic the data structure of the GNOME Shell's JavaScript source code.
+- To add TypeScript type definitions, mimic the data structure of the GNOME Shell's JavaScript source code. Private and protected methods and fields must not have visibility modifiers (making them implicitly public), and public ones must be marked as such.
 - Contributions can range from adding a few types you need for your project to more extensive contributions.
 
 ### Development Instructions:

--- a/packages/gnome-shell/src/misc/loginManager.d.ts
+++ b/packages/gnome-shell/src/misc/loginManager.d.ts
@@ -9,9 +9,9 @@ import * as Signals from './signals.js';
  * Class representing an interface to the systemd login manager.
  */
 declare class LoginManagerSystemd extends Signals.EventEmitter {
-    private _proxy: Gio.DBusProxy;
-    private _userProxy: Gio.DBusProxy;
-    private _currentSession: Gio.DBusProxy | null;
+    _proxy: Gio.DBusProxy;
+    _userProxy: Gio.DBusProxy;
+    _currentSession: Gio.DBusProxy | null;
 
     constructor();
 

--- a/packages/gnome-shell/src/misc/parentalControlsManager.d.ts
+++ b/packages/gnome-shell/src/misc/parentalControlsManager.d.ts
@@ -6,10 +6,10 @@ import type Shell from '@girs/shell-16';
 
 declare class ParentalControlsManager extends GObject.Object {
     _initialized: boolean;
-    public readonly initialized: boolean;
+    readonly initialized: boolean;
 
     constructor();
-    public _init(): void;
+    _init(): void;
 
     _initializeManager(): Promise<void>;
     _onAppFilterChanged(manager: any, uid: ReturnType<typeof Shell.util_get_uid>): void;

--- a/packages/gnome-shell/src/misc/parentalControlsManager.d.ts
+++ b/packages/gnome-shell/src/misc/parentalControlsManager.d.ts
@@ -5,7 +5,7 @@ import type Gio from '@girs/gio-2.0';
 import type Shell from '@girs/shell-16';
 
 declare class ParentalControlsManager extends GObject.Object {
-    protected _initialized: boolean;
+    _initialized: boolean;
     public readonly initialized: boolean;
 
     constructor();

--- a/packages/gnome-shell/src/misc/systemActions.d.ts
+++ b/packages/gnome-shell/src/misc/systemActions.d.ts
@@ -19,16 +19,16 @@ export interface ActionDetails {
  * Class representing system-wide actions such as power off, restart, lock screen, etc.
  */
 declare class SystemActions extends GObject.Object {
-    private _canHavePowerOff: boolean;
-    private _canHaveSuspend: boolean;
-    private _suspendNeedsAuth: boolean;
-    private _loginScreenSettings: Gio.Settings;
-    private _lockdownSettings: Gio.Settings;
-    private _orientationSettings: Gio.Settings;
-    private _session: ReturnType<typeof SessionManager>;
-    private _loginManager: ReturnType<typeof LoginManager.getLoginManager>;
-    private _userManager: AccountsService.UserManager;
-    private _actions: Map<string, ActionDetails>;
+    _canHavePowerOff: boolean;
+    _canHaveSuspend: boolean;
+    _suspendNeedsAuth: boolean;
+    _loginScreenSettings: Gio.Settings;
+    _lockdownSettings: Gio.Settings;
+    _orientationSettings: Gio.Settings;
+    _session: ReturnType<typeof SessionManager>;
+    _loginManager: ReturnType<typeof LoginManager.getLoginManager>;
+    _userManager: AccountsService.UserManager;
+    _actions: Map<string, ActionDetails>;
 
     constructor();
 

--- a/packages/gnome-shell/src/ui/animation.d.ts
+++ b/packages/gnome-shell/src/ui/animation.d.ts
@@ -14,12 +14,12 @@ export class Animation extends St.Bin {
     public play(): void;
     public stop(): void;
 
-    protected _loadFile(file: Gio.File, width: number, height: number): void;
-    protected _showFrame(frame: number): void;
-    protected _update(): typeof GLib.SOURCE_CONTINUE;
-    protected _syncAnimationSize(): void;
-    protected _animationsLoaded(): void;
-    protected _onDestroy(): void;
+    _loadFile(file: Gio.File, width: number, height: number): void;
+    _showFrame(frame: number): void;
+    _update(): typeof GLib.SOURCE_CONTINUE;
+    _syncAnimationSize(): void;
+    _animationsLoaded(): void;
+    _onDestroy(): void;
 }
 
 export class AnimatedIcon extends Animation {
@@ -44,5 +44,5 @@ export class Spinner extends AnimatedIcon {
     public play(): void;
     public stop(): void;
 
-    protected _onDestroy(): void;
+    _onDestroy(): void;
 }

--- a/packages/gnome-shell/src/ui/animation.d.ts
+++ b/packages/gnome-shell/src/ui/animation.d.ts
@@ -8,11 +8,11 @@ export class Animation extends St.Bin {
     constructor(file: Gio.File, width: number, height: number, speed: number);
 
     /** @hidden */
-    public _init(props?: Partial<St.Bin.ConstructorProps>): void;
-    public _init(file: Gio.File, width: number, height: number, speed: number): void;
+    _init(props?: Partial<St.Bin.ConstructorProps>): void;
+    _init(file: Gio.File, width: number, height: number, speed: number): void;
 
-    public play(): void;
-    public stop(): void;
+    play(): void;
+    stop(): void;
 
     _loadFile(file: Gio.File, width: number, height: number): void;
     _showFrame(frame: number): void;
@@ -25,24 +25,24 @@ export class Animation extends St.Bin {
 export class AnimatedIcon extends Animation {
     constructor(file: Gio.File, size: number);
     /** @hidden */
-    public _init(props?: Partial<St.Bin.ConstructorProps>): void;
+    _init(props?: Partial<St.Bin.ConstructorProps>): void;
     /** @hidden */
-    public _init(file: Gio.File, width: number, height: number, speed: number): void;
-    public _init(file: Gio.File, size: number): void;
+    _init(file: Gio.File, width: number, height: number, speed: number): void;
+    _init(file: Gio.File, size: number): void;
 }
 
 export class Spinner extends AnimatedIcon {
     constructor(size: number, params: { animate: boolean; hideOnStop: boolean });
     /** @hidden */
-    public _init(props?: Partial<St.Bin.ConstructorProps>): void;
+    _init(props?: Partial<St.Bin.ConstructorProps>): void;
     /** @hidden */
-    public _init(file: Gio.File, width: number, height: number, speed: number): void;
+    _init(file: Gio.File, width: number, height: number, speed: number): void;
     /** @hidden */
-    public _init(file: Gio.File, size: number): void;
-    public _init(size: number, params: { animate: boolean; hideOnStop: boolean }): void;
+    _init(file: Gio.File, size: number): void;
+    _init(size: number, params: { animate: boolean; hideOnStop: boolean }): void;
 
-    public play(): void;
-    public stop(): void;
+    play(): void;
+    stop(): void;
 
     _onDestroy(): void;
 }

--- a/packages/gnome-shell/src/ui/appDisplay.d.ts
+++ b/packages/gnome-shell/src/ui/appDisplay.d.ts
@@ -16,7 +16,7 @@ export class AppGrid extends IconGrid {
     public _init(params?: Partial<St.Viewport.ConstructorProps>): void;
     public _init(layoutParams?: Partial<IconGrid.ConstructorProps>): void;
 
-    protected _updatePadding(): void;
+    _updatePadding(): void;
 }
 
 export abstract class BaseAppView extends St.Widget {
@@ -24,35 +24,35 @@ export abstract class BaseAppView extends St.Widget {
     constructor(params?: Partial<St.Widget.ConstructorProps>);
     public _init(params?: Partial<St.Widget.ConstructorProps>): void;
 
-    protected _onDestroy(): void;
-    protected _createGrid(): AppGrid;
-    protected _onScroll(actor: St.Widget, event: Clutter.ScrollEvent): boolean;
-    protected _swipeBegin(tracker: any, monitor: Clutter.EventSequence): void;
-    protected _swipeUpdate(tracker: any, progress: number): void;
-    protected _swipeEnd(tracker: any, duration: number, endProgress: number): void;
-    protected _connectDnD(): void;
-    protected _disconnectDnD(): void;
-    protected _maybeMoveItem(dragEvent: Clutter.Event): void;
-    protected _removeDelayedMove(): void;
-    protected _resetDragPageSwitch(): void;
-    protected _setupDragPageSwitchRepeat(direction: number): void;
-    protected _dragMaybeSwitchPageImmediately(dragEvent: Clutter.Event): void;
-    protected _maybeSetupDragPageSwitchInitialTimeout(dragEvent: Clutter.Event): void;
-    protected _onDragBegin(): void;
-    protected _onDragMotion(dragEvent: Clutter.Event): boolean;
-    protected _onDragDrop(dropEvent: Clutter.Event): boolean;
-    protected _onDragEnd(): void;
-    protected _onDragCancelled(): void;
-    protected _canAccept(source: any): boolean;
-    protected _findBestPageToAppend(startPage?: number): number;
-    protected _getLinearPosition(page: number, position: number): number;
-    protected _addItem(item: any, page: number, position: number): void;
-    protected _removeItem(item: any): void;
-    protected _redisplay(): void;
-    protected _compareItems(a: any, b: any): number;
-    protected _selectAppInternal(id: string): void;
-    protected _getDropTarget(x: number, y: number, source: any): [number, number, number];
-    protected _moveItem(item: any, newPage: number, newPosition: number): void;
+    _onDestroy(): void;
+    _createGrid(): AppGrid;
+    _onScroll(actor: St.Widget, event: Clutter.ScrollEvent): boolean;
+    _swipeBegin(tracker: any, monitor: Clutter.EventSequence): void;
+    _swipeUpdate(tracker: any, progress: number): void;
+    _swipeEnd(tracker: any, duration: number, endProgress: number): void;
+    _connectDnD(): void;
+    _disconnectDnD(): void;
+    _maybeMoveItem(dragEvent: Clutter.Event): void;
+    _removeDelayedMove(): void;
+    _resetDragPageSwitch(): void;
+    _setupDragPageSwitchRepeat(direction: number): void;
+    _dragMaybeSwitchPageImmediately(dragEvent: Clutter.Event): void;
+    _maybeSetupDragPageSwitchInitialTimeout(dragEvent: Clutter.Event): void;
+    _onDragBegin(): void;
+    _onDragMotion(dragEvent: Clutter.Event): boolean;
+    _onDragDrop(dropEvent: Clutter.Event): boolean;
+    _onDragEnd(): void;
+    _onDragCancelled(): void;
+    _canAccept(source: any): boolean;
+    _findBestPageToAppend(startPage?: number): number;
+    _getLinearPosition(page: number, position: number): number;
+    _addItem(item: any, page: number, position: number): void;
+    _removeItem(item: any): void;
+    _redisplay(): void;
+    _compareItems(a: any, b: any): number;
+    _selectAppInternal(id: string): void;
+    _getDropTarget(x: number, y: number, source: any): [number, number, number];
+    _moveItem(item: any, newPage: number, newPosition: number): void;
 
     public handleDragOver(source: any): DragMotionResult;
     public acceptDrop(source: any): boolean;
@@ -68,26 +68,26 @@ export class AppDisplay extends BaseAppView {
     constructor();
     public _init(): void;
 
-    protected _onDestroy(): void;
-    protected _redisplay(): void;
-    protected _savePages(): void;
-    protected _ensureDefaultFolders(): void;
-    protected _ensurePlaceholder(source: any): void;
-    protected _removePlaceholder(): void;
-    protected _getItemPosition(item: any): [number, number];
-    protected _compareItems(a: any, b: any): number;
-    protected _loadApps(): void;
-    protected _onScroll(actor: St.Widget, event: Clutter.ScrollEvent): boolean;
-    protected _onKeyPressEvent(actor: St.Widget, event: Clutter.KeyEvent): boolean;
-    protected _maybeMoveItem(dragEvent: Clutter.Event): void;
+    _onDestroy(): void;
+    _redisplay(): void;
+    _savePages(): void;
+    _ensureDefaultFolders(): void;
+    _ensurePlaceholder(source: any): void;
+    _removePlaceholder(): void;
+    _getItemPosition(item: any): [number, number];
+    _compareItems(a: any, b: any): number;
+    _loadApps(): void;
+    _onScroll(actor: St.Widget, event: Clutter.ScrollEvent): boolean;
+    _onKeyPressEvent(actor: St.Widget, event: Clutter.KeyEvent): boolean;
+    _maybeMoveItem(dragEvent: Clutter.Event): void;
     /** @hidden */
-    protected _onDragBegin(): void;
-    protected _onDragBegin(overview: any, source: any): void;
-    protected _onDragMotion(dragEvent: Clutter.Event): boolean;
-    protected _onDragEnd(): void;
+    _onDragBegin(): void;
+    _onDragBegin(overview: any, source: any): void;
+    _onDragMotion(dragEvent: Clutter.Event): boolean;
+    _onDragEnd(): void;
     /** @hidden */
-    protected _onDragCancelled(): void;
-    protected _onDragCancelled(overview: any, source: any): void;
+    _onDragCancelled(): void;
+    _onDragCancelled(overview: any, source: any): void;
 
     public getAppInfos(): any[];
     public animateSwitch(animationDirection: number): void;
@@ -114,16 +114,16 @@ export class AppViewItem extends St.Button {
     constructor(params?: Partial<St.Button.ConstructorProps>);
     public _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
 
-    protected _onDestroy(): void;
-    protected _updateMultiline(): void;
-    protected _onHover(): void;
-    protected _onDragBegin(): void;
-    protected _onDragCancelled(): void;
-    protected _onDragEnd(): void;
-    protected _canAccept(source: any): boolean;
-    protected _setHoveringByDnd(hovering: boolean): void;
-    protected _onDragMotion(dragEvent: Clutter.Event): boolean;
-    protected _withinLeeways(x: number): boolean;
+    _onDestroy(): void;
+    _updateMultiline(): void;
+    _onHover(): void;
+    _onDragBegin(): void;
+    _onDragCancelled(): void;
+    _onDragEnd(): void;
+    _canAccept(source: any): boolean;
+    _setHoveringByDnd(hovering: boolean): void;
+    _onDragMotion(dragEvent: Clutter.Event): boolean;
+    _withinLeeways(x: number): boolean;
 
     public scaleIn(): void;
     public scaleAndFade(): void;
@@ -145,10 +145,10 @@ export class AppIcon extends AppViewItem {
     public app: any;
     public icon: BaseIcon;
 
-    protected _id: string;
-    protected _name: string;
-    protected _iconContainer: St.Widget;
-    protected _folderPreviewId: number;
+    _id: string;
+    _name: string;
+    _iconContainer: St.Widget;
+    _folderPreviewId: number;
 
     constructor(app: any, iconParams?: AppIcon.ConstructorProps);
 
@@ -156,17 +156,17 @@ export class AppIcon extends AppViewItem {
     public _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
     public _init(app: any, iconParams?: Partial<AppIcon.ConstructorProps>): void;
 
-    protected _onDestroy(): void;
-    protected _createIcon(iconSize: number): St.Widget;
-    protected _removeMenuTimeout(): void;
-    protected _setPopupTimeout(): void;
-    protected _onKeyboardPopupMenu(): void;
-    protected _onMenuPoppedDown(): void;
-    protected _onMenuPoppedDown(button: St.Button): void;
-    protected _showFolderPreview(): void;
-    protected _hideFolderPreview(): void;
-    protected _canAccept(source: any): boolean;
-    protected _setHoveringByDnd(hovering: boolean): void;
+    _onDestroy(): void;
+    _createIcon(iconSize: number): St.Widget;
+    _removeMenuTimeout(): void;
+    _setPopupTimeout(): void;
+    _onKeyboardPopupMenu(): void;
+    _onMenuPoppedDown(): void;
+    _onMenuPoppedDown(button: St.Button): void;
+    _showFolderPreview(): void;
+    _hideFolderPreview(): void;
+    _canAccept(source: any): boolean;
+    _setHoveringByDnd(hovering: boolean): void;
 
     public onDragBegin(): void;
     public updateRunningStyle(): void;

--- a/packages/gnome-shell/src/ui/appDisplay.d.ts
+++ b/packages/gnome-shell/src/ui/appDisplay.d.ts
@@ -10,11 +10,11 @@ import { IconGrid, BaseIcon } from './iconGrid.js';
 import { DragMotionResult } from './dnd.js';
 
 export class AppGrid extends IconGrid {
-    public indicatorsPadding: number;
+    indicatorsPadding: number;
 
     /** @hidden */
-    public _init(params?: Partial<St.Viewport.ConstructorProps>): void;
-    public _init(layoutParams?: Partial<IconGrid.ConstructorProps>): void;
+    _init(params?: Partial<St.Viewport.ConstructorProps>): void;
+    _init(layoutParams?: Partial<IconGrid.ConstructorProps>): void;
 
     _updatePadding(): void;
 }
@@ -22,7 +22,7 @@ export class AppGrid extends IconGrid {
 export abstract class BaseAppView extends St.Widget {
     // TODO: 'view-loaded' signal
     constructor(params?: Partial<St.Widget.ConstructorProps>);
-    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
+    _init(params?: Partial<St.Widget.ConstructorProps>): void;
 
     _onDestroy(): void;
     _createGrid(): AppGrid;
@@ -54,19 +54,19 @@ export abstract class BaseAppView extends St.Widget {
     _getDropTarget(x: number, y: number, source: any): [number, number, number];
     _moveItem(item: any, newPage: number, newPosition: number): void;
 
-    public handleDragOver(source: any): DragMotionResult;
-    public acceptDrop(source: any): boolean;
-    public getItemPosition(item: any): [number, number];
-    public getAllItems(): any[];
-    public selectApp(id: string): void;
-    public animateSwitch(animationDirection: number): void;
-    public goToPage(pageNumber: number, animate: boolean): void;
-    public updateDragFocus(dragFocus: any): void;
+    handleDragOver(source: any): DragMotionResult;
+    acceptDrop(source: any): boolean;
+    getItemPosition(item: any): [number, number];
+    getAllItems(): any[];
+    selectApp(id: string): void;
+    animateSwitch(animationDirection: number): void;
+    goToPage(pageNumber: number, animate: boolean): void;
+    updateDragFocus(dragFocus: any): void;
 }
 
 export class AppDisplay extends BaseAppView {
     constructor();
-    public _init(): void;
+    _init(): void;
 
     _onDestroy(): void;
     _redisplay(): void;
@@ -89,22 +89,22 @@ export class AppDisplay extends BaseAppView {
     _onDragCancelled(): void;
     _onDragCancelled(overview: any, source: any): void;
 
-    public getAppInfos(): any[];
-    public animateSwitch(animationDirection: number): void;
-    public goToPage(pageNumber: number, animate?: boolean): void;
-    public addFolderDialog(dialog: any): void;
-    public acceptDrop(source: any): boolean;
-    public createFolder(apps: any[]): boolean;
+    getAppInfos(): any[];
+    animateSwitch(animationDirection: number): void;
+    goToPage(pageNumber: number, animate?: boolean): void;
+    addFolderDialog(dialog: any): void;
+    acceptDrop(source: any): boolean;
+    createFolder(apps: any[]): boolean;
 }
 
 export class AppSearchProvider {
     constructor();
 
-    public getResultMetas(apps: any[]): Promise<any[]>;
-    public filterResults(results: any[], maxNumber: number): any[];
-    public getInitialResultSet(terms: string[], cancellable: Gio.Cancellable): Promise<any[]>;
-    public getSubsearchResultSet(previousResults: any[], terms: string[], cancellable: Gio.Cancellable): any[];
-    public createResultObject(resultMeta: any): AppIcon | SystemActionIcon;
+    getResultMetas(apps: any[]): Promise<any[]>;
+    filterResults(results: any[], maxNumber: number): any[];
+    getInitialResultSet(terms: string[], cancellable: Gio.Cancellable): Promise<any[]>;
+    getSubsearchResultSet(previousResults: any[], terms: string[], cancellable: Gio.Cancellable): any[];
+    createResultObject(resultMeta: any): AppIcon | SystemActionIcon;
 }
 
 export class AppViewItem extends St.Button {
@@ -112,7 +112,7 @@ export class AppViewItem extends St.Button {
     readonly app: any;
 
     constructor(params?: Partial<St.Button.ConstructorProps>);
-    public _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
+    _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
 
     _onDestroy(): void;
     _updateMultiline(): void;
@@ -125,13 +125,13 @@ export class AppViewItem extends St.Button {
     _onDragMotion(dragEvent: Clutter.Event): boolean;
     _withinLeeways(x: number): boolean;
 
-    public scaleIn(): void;
-    public scaleAndFade(): void;
-    public undoScaleAndFade(): void;
-    public handleDragOver(source: any, actor: St.Widget, x: number): DragMotionResult;
-    public acceptDrop(source: any, actor: St.Widget, x: number): boolean;
-    public cancelActions(): void;
-    public setForcedHighlight(highlight: boolean): void;
+    scaleIn(): void;
+    scaleAndFade(): void;
+    undoScaleAndFade(): void;
+    handleDragOver(source: any, actor: St.Widget, x: number): DragMotionResult;
+    acceptDrop(source: any, actor: St.Widget, x: number): boolean;
+    cancelActions(): void;
+    setForcedHighlight(highlight: boolean): void;
 }
 
 export namespace AppIcon {
@@ -142,8 +142,8 @@ export namespace AppIcon {
 }
 
 export class AppIcon extends AppViewItem {
-    public app: any;
-    public icon: BaseIcon;
+    app: any;
+    icon: BaseIcon;
 
     _id: string;
     _name: string;
@@ -153,8 +153,8 @@ export class AppIcon extends AppViewItem {
     constructor(app: any, iconParams?: AppIcon.ConstructorProps);
 
     /** @hidden */
-    public _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
-    public _init(app: any, iconParams?: Partial<AppIcon.ConstructorProps>): void;
+    _init(params?: Partial<St.Button.ConstructorProps>, isDraggable?: boolean, expandTitleOnHover?: boolean): void;
+    _init(app: any, iconParams?: Partial<AppIcon.ConstructorProps>): void;
 
     _onDestroy(): void;
     _createIcon(iconSize: number): St.Widget;
@@ -168,21 +168,21 @@ export class AppIcon extends AppViewItem {
     _canAccept(source: any): boolean;
     _setHoveringByDnd(hovering: boolean): void;
 
-    public onDragBegin(): void;
-    public updateRunningStyle(): void;
-    public getId(): string;
-    public popupMenu(side?: St.Side): void;
-    public animateLaunch(): void;
-    public animateLaunchAtPos(x: number, y: number): void;
-    public shellWorkspaceLaunch(params?: { workspace: number; timestamp: number }): void;
-    public getDragActor(): St.Widget;
+    onDragBegin(): void;
+    updateRunningStyle(): void;
+    getId(): string;
+    popupMenu(side?: St.Side): void;
+    animateLaunch(): void;
+    animateLaunchAtPos(x: number, y: number): void;
+    shellWorkspaceLaunch(params?: { workspace: number; timestamp: number }): void;
+    getDragActor(): St.Widget;
     /**
      * @returns The original actor that should align with the actor we show as the item is being dragged.
      */
-    public getDragActorSource(): St.Widget;
-    public shouldShowTooltip(): boolean;
-    public acceptDrop(source: any, actor: St.Widget, x: number): boolean;
-    public cancelActions(): void;
+    getDragActorSource(): St.Widget;
+    shouldShowTooltip(): boolean;
+    acceptDrop(source: any, actor: St.Widget, x: number): boolean;
+    cancelActions(): void;
 }
 
 export class SystemActionIcon extends GridSearchResult {

--- a/packages/gnome-shell/src/ui/appFavorites.d.ts
+++ b/packages/gnome-shell/src/ui/appFavorites.d.ts
@@ -5,14 +5,14 @@ import type Shell from '@girs/shell-16';
 import { EventEmitter } from '../misc/signals.js';
 
 declare class AppFavorites extends EventEmitter {
-    protected _favorites: Map<string, Shell.App>;
+    _favorites: Map<string, Shell.App>;
 
     constructor();
 
-    protected _onFavsChanged(): void;
-    protected _getIds(): string[];
-    protected _addFavorite(appId: string, pos: number): void;
-    protected _removeFavorite(appId: string): void;
+    _onFavsChanged(): void;
+    _getIds(): string[];
+    _addFavorite(appId: string, pos: number): void;
+    _removeFavorite(appId: string): void;
 
     public reload(): void;
     public getFavoriteMap(): Map<string, Shell.App>;

--- a/packages/gnome-shell/src/ui/appFavorites.d.ts
+++ b/packages/gnome-shell/src/ui/appFavorites.d.ts
@@ -14,14 +14,14 @@ declare class AppFavorites extends EventEmitter {
     _addFavorite(appId: string, pos: number): void;
     _removeFavorite(appId: string): void;
 
-    public reload(): void;
-    public getFavoriteMap(): Map<string, Shell.App>;
-    public getFavorites(): Shell.App[];
-    public isFavorite(appId: string): boolean;
-    public addFavoriteAtPos(appId: string, pos: number): void;
-    public addFavorite(appId: string): void;
-    public moveFavoriteToPos(appId: string, pos: number): void;
-    public removeFavorite(appId: string): void;
+    reload(): void;
+    getFavoriteMap(): Map<string, Shell.App>;
+    getFavorites(): Shell.App[];
+    isFavorite(appId: string): boolean;
+    addFavoriteAtPos(appId: string, pos: number): void;
+    addFavorite(appId: string): void;
+    moveFavoriteToPos(appId: string, pos: number): void;
+    removeFavorite(appId: string): void;
 }
 
 export function getAppFavorites(): AppFavorites;

--- a/packages/gnome-shell/src/ui/appMenu.d.ts
+++ b/packages/gnome-shell/src/ui/appMenu.d.ts
@@ -47,15 +47,15 @@ export class AppMenu extends PopupMenu {
     _queueUpdateWindowsSection(): void;
     _updateWindowsSection(): void;
 
-    public destroy(): void;
+    destroy(): void;
 
     /**
      * @returns true if the menu is empty
      */
-    public isEmpty(): boolean;
+    isEmpty(): boolean;
 
     /**
      * @param app the app the menu represents
      */
-    public setApp(app: Shell.App): void;
+    setApp(app: Shell.App): void;
 }

--- a/packages/gnome-shell/src/ui/appMenu.d.ts
+++ b/packages/gnome-shell/src/ui/appMenu.d.ts
@@ -9,23 +9,23 @@ import type { getAppFavorites } from './appFavorites.js';
 import type { getDefault } from '../misc/parentalControlsManager.js';
 
 export class AppMenu extends PopupMenu {
-    protected _app: Shell.App | null;
-    protected _appSystem: Shell.AppSystem;
-    protected _parentalControlsManager: ReturnType<typeof getDefault>;
-    protected _appFavorites: ReturnType<typeof getAppFavorites>;
-    protected _enableFavorites: boolean;
-    protected _showSingleWindows: boolean;
+    _app: Shell.App | null;
+    _appSystem: Shell.AppSystem;
+    _parentalControlsManager: ReturnType<typeof getDefault>;
+    _appFavorites: ReturnType<typeof getAppFavorites>;
+    _enableFavorites: boolean;
+    _showSingleWindows: boolean;
 
-    protected _windowsChangedId: number;
-    protected _updateWindowsLaterId: number;
+    _windowsChangedId: number;
+    _updateWindowsLaterId: number;
 
-    protected _openWindowsHeader: PopupSeparatorMenuItem;
-    protected _windowSection: PopupMenuSection;
-    protected _newWindowItem: ReturnType<typeof this.addAction>;
-    protected _actionSection: PopupMenuSection;
-    protected _onGpuMenuItem: ReturnType<typeof this.addAction>;
-    protected _detailsItem: ReturnType<typeof this.addAction>;
-    protected _quitItem: ReturnType<typeof this.addAction>;
+    _openWindowsHeader: PopupSeparatorMenuItem;
+    _windowSection: PopupMenuSection;
+    _newWindowItem: ReturnType<typeof this.addAction>;
+    _actionSection: PopupMenuSection;
+    _onGpuMenuItem: ReturnType<typeof this.addAction>;
+    _detailsItem: ReturnType<typeof this.addAction>;
+    _quitItem: ReturnType<typeof this.addAction>;
 
     /**
      * @param sourceActor - actor the menu is attached to
@@ -36,16 +36,16 @@ export class AppMenu extends PopupMenu {
      */
     constructor(sourceActor: Clutter.Actor, side?: St.Side, params?: { favoritesSection?: boolean; showSingleWindow: boolean });
 
-    protected _onAppStateChanged(sys: any, app: any): void;
-    protected _updateQuitItem(): void;
-    protected _updateNewWindowItem(): void;
-    protected _updateFavoriteItem(): void;
-    protected _updateGpuItem(): void;
-    protected _updateDetailsVisibility(): void;
-    protected _animateLaunch(): void;
-    protected _getNonDefaultLaunchGpu(): Shell.AppLaunchGpu;
-    protected _queueUpdateWindowsSection(): void;
-    protected _updateWindowsSection(): void;
+    _onAppStateChanged(sys: any, app: any): void;
+    _updateQuitItem(): void;
+    _updateNewWindowItem(): void;
+    _updateFavoriteItem(): void;
+    _updateGpuItem(): void;
+    _updateDetailsVisibility(): void;
+    _animateLaunch(): void;
+    _getNonDefaultLaunchGpu(): Shell.AppLaunchGpu;
+    _queueUpdateWindowsSection(): void;
+    _updateWindowsSection(): void;
 
     public destroy(): void;
 

--- a/packages/gnome-shell/src/ui/audioDeviceSelection.d.ts
+++ b/packages/gnome-shell/src/ui/audioDeviceSelection.d.ts
@@ -20,21 +20,21 @@ declare class AudioDeviceSelectionDialog extends ModalDialog {
     public _init(props?: Partial<ModalDialog.ConstructorProps>): void;
     public _init(devices: number): void;
 
-    protected _buildLayout(): void;
-    protected _getDeviceLabel(device: AudioDevice): string | null;
-    protected _getDeviceIcon(device: AudioDevice): string | null;
-    protected _addDevice(device: AudioDevice): void;
-    protected _openSettings(): void;
+    _buildLayout(): void;
+    _getDeviceLabel(device: AudioDevice): string | null;
+    _getDeviceIcon(device: AudioDevice): string | null;
+    _addDevice(device: AudioDevice): void;
+    _openSettings(): void;
 }
 
 export class AudioDeviceSelectionDBus {
-    protected _audioSelectionDialog: AudioDeviceSelectionDialog | null;
-    protected _dbusImpl: Gio.DBusExportedObject;
+    _audioSelectionDialog: AudioDeviceSelectionDialog | null;
+    _dbusImpl: Gio.DBusExportedObject;
 
     constructor();
 
-    protected _onDialogClosed(): void;
-    protected _onDeviceSelected(dialog: AudioDeviceSelectionDialog, device: AudioDevice): void;
+    _onDialogClosed(): void;
+    _onDeviceSelected(dialog: AudioDeviceSelectionDialog, device: AudioDevice): void;
 
     OpenAsync(params: string[], invocation: Gio.DBusMethodInvocation): void;
     CloseAsync(params: any, invocation: Gio.DBusMethodInvocation): void;

--- a/packages/gnome-shell/src/ui/audioDeviceSelection.d.ts
+++ b/packages/gnome-shell/src/ui/audioDeviceSelection.d.ts
@@ -15,10 +15,10 @@ declare class AudioDeviceSelectionDialog extends ModalDialog {
     constructor(devices: number);
 
     /** @hidden */
-    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
+    _init(params?: Partial<St.Widget.ConstructorProps>): void;
     /** @hidden */
-    public _init(props?: Partial<ModalDialog.ConstructorProps>): void;
-    public _init(devices: number): void;
+    _init(props?: Partial<ModalDialog.ConstructorProps>): void;
+    _init(devices: number): void;
 
     _buildLayout(): void;
     _getDeviceLabel(device: AudioDevice): string | null;

--- a/packages/gnome-shell/src/ui/background.d.ts
+++ b/packages/gnome-shell/src/ui/background.d.ts
@@ -115,10 +115,10 @@ declare class BackgroundCache extends EventEmitter {
 
     constructor();
 
-    public monitorFile(file: Gio.File): Gio.FileMonitor;
-    public getAnimation(params?: { file?: Gio.File | null; settingsSchema?: Gio.SettingsSchema | null; onLoaded: (animation: Animation) => void }): void;
-    public getBackgroundSource(layoutManager: LayoutManager, settingsSchema: Gio.SettingsSchema): BackgroundSource;
-    public releaseBackgroundSource(settingsSchema: Gio.SettingsSchema): void;
+    monitorFile(file: Gio.File): Gio.FileMonitor;
+    getAnimation(params?: { file?: Gio.File | null; settingsSchema?: Gio.SettingsSchema | null; onLoaded: (animation: Animation) => void }): void;
+    getBackgroundSource(layoutManager: LayoutManager, settingsSchema: Gio.SettingsSchema): BackgroundSource;
+    releaseBackgroundSource(settingsSchema: Gio.SettingsSchema): void;
 }
 
 /**
@@ -136,16 +136,16 @@ declare class Background extends Meta.Background {
     _interfaceSettings: Gio.Settings;
     _clock: GnomeDesktop.WallClock;
 
-    public isLoaded: boolean;
+    isLoaded: boolean;
 
     constructor(params?: { monitorIndex?: number; layoutManager: LayoutManager; settings?: Gio.Settings | null; file: Gio.File | null; style: string | null });
 
     /** @hidden */
-    public _init(params?: Partial<Meta.Background.ConstructorProps>): void;
-    public _init(params?: { monitorIndex?: number; layoutManager: LayoutManager; settings?: Gio.Settings | null; file: Gio.File | null; style: string | null }): void;
+    _init(params?: Partial<Meta.Background.ConstructorProps>): void;
+    _init(params?: { monitorIndex?: number; layoutManager: LayoutManager; settings?: Gio.Settings | null; file: Gio.File | null; style: string | null }): void;
 
-    public destroy(): void;
-    public updateResolution(): void;
+    destroy(): void;
+    updateResolution(): void;
 
     _emitChangedSignal(): void;
     _refreshAnimation(): void;
@@ -165,8 +165,8 @@ export class SystemBackground extends Meta.BackgroundActor {
     constructor();
 
     /** @hidden */
-    public _init(params?: Partial<Meta.BackgroundActor.ConstructorProps>): void;
-    public _init(): void;
+    _init(params?: Partial<Meta.BackgroundActor.ConstructorProps>): void;
+    _init(): void;
 }
 
 /**
@@ -184,8 +184,8 @@ declare class BackgroundSource {
 
     constructor(layoutManager: LayoutManager, settingsSchema: Gio.SettingsSchema);
 
-    public getBackground(monitorIndex: number): Background;
-    public destroy(): void;
+    getBackground(monitorIndex: number): Background;
+    destroy(): void;
 
     _onMonitorsChanged(): void;
 }
@@ -195,7 +195,7 @@ declare class BackgroundSource {
  * wrapper for GnomeBG.BGSlideShow
  */
 declare class Animation extends GnomeBG.BGSlideShow {
-    public _init(params?: Partial<GnomeBG.BGSlideShow.ConstructorProps>): void;
+    _init(params?: Partial<GnomeBG.BGSlideShow.ConstructorProps>): void;
 
     /** @hidden */
     load_async(cancellable: Gio.Cancellable | null, callback: Gio.AsyncReadyCallback<this> | null): void;
@@ -227,11 +227,11 @@ export class BackgroundManager extends EventEmitter {
     _useContentSize: boolean;
     _newBackgroundActor: Meta.BackgroundActor;
 
-    public backgroundActor: Meta.BackgroundActor;
+    backgroundActor: Meta.BackgroundActor;
 
     constructor(params: { container?: Clutter.Actor | null; layoutManager?: LayoutManager; monitorIndex?: number | null; vignette?: boolean; controlPosition?: boolean; settingsSchema?: Gio.SettingsSchema; useContentSize?: boolean });
 
-    public destroy(): void;
+    destroy(): void;
 
     _swapBackgroundActor(): void;
     _updateBackgroundActor(): void;

--- a/packages/gnome-shell/src/ui/background.d.ts
+++ b/packages/gnome-shell/src/ui/background.d.ts
@@ -109,9 +109,9 @@ import type { LayoutManager, Monitor } from './layout.js';
  * Also used to share file monitors.
  */
 declare class BackgroundCache extends EventEmitter {
-    protected _backgroundSources: Map<string, BackgroundSource>;
-    protected _fileMonitors: Map<string, Gio.FileMonitor>;
-    protected _animations: Map<string, Animation>;
+    _backgroundSources: Map<string, BackgroundSource>;
+    _fileMonitors: Map<string, Gio.FileMonitor>;
+    _animations: Map<string, Animation>;
 
     constructor();
 
@@ -126,15 +126,15 @@ declare class BackgroundCache extends EventEmitter {
  * schema for the background.
  */
 declare class Background extends Meta.Background {
-    protected _settings: Gio.Settings | null;
-    protected _file: Gio.File | null;
-    protected _style: string | null;
-    protected _monitorIndex: number;
-    protected _layoutManager: LayoutManager;
-    protected _fileWatches: Map<string, Gio.FileMonitor>;
-    protected _cancellable: Gio.Cancellable;
-    protected _interfaceSettings: Gio.Settings;
-    protected _clock: GnomeDesktop.WallClock;
+    _settings: Gio.Settings | null;
+    _file: Gio.File | null;
+    _style: string | null;
+    _monitorIndex: number;
+    _layoutManager: LayoutManager;
+    _fileWatches: Map<string, Gio.FileMonitor>;
+    _cancellable: Gio.Cancellable;
+    _interfaceSettings: Gio.Settings;
+    _clock: GnomeDesktop.WallClock;
 
     public isLoaded: boolean;
 
@@ -147,18 +147,18 @@ declare class Background extends Meta.Background {
     public destroy(): void;
     public updateResolution(): void;
 
-    protected _emitChangedSignal(): void;
-    protected _refreshAnimation(): void;
-    protected _setLoaded(): void;
-    protected _loadPattern(): void;
-    protected _watchFile(file: Gio.File): void;
-    protected _removeAnimationTimeout(): void;
-    protected _updateAnimation(): void;
-    protected _queueUpdateAnimation(): void;
-    protected _loadAnimation(file: Gio.File): void;
-    protected _loadImage(file: Gio.File): void;
-    protected _loadFile(file: Gio.File): Promise<void>;
-    protected _load(): void;
+    _emitChangedSignal(): void;
+    _refreshAnimation(): void;
+    _setLoaded(): void;
+    _loadPattern(): void;
+    _watchFile(file: Gio.File): void;
+    _removeAnimationTimeout(): void;
+    _updateAnimation(): void;
+    _queueUpdateAnimation(): void;
+    _loadAnimation(file: Gio.File): void;
+    _loadImage(file: Gio.File): void;
+    _loadFile(file: Gio.File): Promise<void>;
+    _load(): void;
 }
 
 export class SystemBackground extends Meta.BackgroundActor {
@@ -175,19 +175,19 @@ export class SystemBackground extends Meta.BackgroundActor {
  * and holds a reference to shared Background objects.
  */
 declare class BackgroundSource {
-    protected _layoutManager: LayoutManager;
-    protected _overrideImage: string | null;
-    protected _settings: Gio.Settings;
-    protected _backgrounds: Background[];
-    protected _monitorsChangedId: number;
-    protected _interfaceSettings: Gio.Settings;
+    _layoutManager: LayoutManager;
+    _overrideImage: string | null;
+    _settings: Gio.Settings;
+    _backgrounds: Background[];
+    _monitorsChangedId: number;
+    _interfaceSettings: Gio.Settings;
 
     constructor(layoutManager: LayoutManager, settingsSchema: Gio.SettingsSchema);
 
     public getBackground(monitorIndex: number): Background;
     public destroy(): void;
 
-    protected _onMonitorsChanged(): void;
+    _onMonitorsChanged(): void;
 }
 
 /**
@@ -217,15 +217,15 @@ declare class Animation extends GnomeBG.BGSlideShow {
  * since using two actors is quite inefficient.)
  */
 export class BackgroundManager extends EventEmitter {
-    protected _settingsSchema: Gio.SettingsSchema;
-    protected _backgroundSource: BackgroundSource;
-    protected _container: Clutter.Actor | null;
-    protected _layoutManager: LayoutManager;
-    protected _vignette: boolean;
-    protected _monitorIndex: number | null;
-    protected _controlPosition: boolean;
-    protected _useContentSize: boolean;
-    protected _newBackgroundActor: Meta.BackgroundActor;
+    _settingsSchema: Gio.SettingsSchema;
+    _backgroundSource: BackgroundSource;
+    _container: Clutter.Actor | null;
+    _layoutManager: LayoutManager;
+    _vignette: boolean;
+    _monitorIndex: number | null;
+    _controlPosition: boolean;
+    _useContentSize: boolean;
+    _newBackgroundActor: Meta.BackgroundActor;
 
     public backgroundActor: Meta.BackgroundActor;
 
@@ -233,7 +233,7 @@ export class BackgroundManager extends EventEmitter {
 
     public destroy(): void;
 
-    protected _swapBackgroundActor(): void;
-    protected _updateBackgroundActor(): void;
-    protected _createBackgroundActor(): Meta.BackgroundActor;
+    _swapBackgroundActor(): void;
+    _updateBackgroundActor(): void;
+    _createBackgroundActor(): Meta.BackgroundActor;
 }

--- a/packages/gnome-shell/src/ui/barLevel.d.ts
+++ b/packages/gnome-shell/src/ui/barLevel.d.ts
@@ -12,14 +12,14 @@ export class BarLevel extends St.DrawingArea {
     _overdriveStart: number;
     _barLevelWidth: number;
 
-    public value: number;
-    public maximumValue: number;
-    public overdriveStart: number;
+    value: number;
+    maximumValue: number;
+    overdriveStart: number;
 
     constructor(params?: Partial<BarLevel.ConstructorProps>);
-    public _init(params?: Partial<BarLevel.ConstructorProps>): void;
+    _init(params?: Partial<BarLevel.ConstructorProps>): void;
 
-    public vfunc_repaint(): void;
+    vfunc_repaint(): void;
 
     _getCurrentValue(): number;
     _getOverdriveStart(): number;

--- a/packages/gnome-shell/src/ui/barLevel.d.ts
+++ b/packages/gnome-shell/src/ui/barLevel.d.ts
@@ -7,10 +7,10 @@ export namespace BarLevel {
 }
 
 export class BarLevel extends St.DrawingArea {
-    protected _maxValue: number;
-    protected _value: number;
-    protected _overdriveStart: number;
-    protected _barLevelWidth: number;
+    _maxValue: number;
+    _value: number;
+    _overdriveStart: number;
+    _barLevelWidth: number;
 
     public value: number;
     public maximumValue: number;
@@ -21,10 +21,10 @@ export class BarLevel extends St.DrawingArea {
 
     public vfunc_repaint(): void;
 
-    protected _getCurrentValue(): number;
-    protected _getOverdriveStart(): number;
-    protected _getMinimumValue(): number;
-    protected _getMaximumValue(): number;
-    protected _setCurrentValue(_actor: any, value: number): void;
-    protected _valueChanged(): void;
+    _getCurrentValue(): number;
+    _getOverdriveStart(): number;
+    _getMinimumValue(): number;
+    _getMaximumValue(): number;
+    _setCurrentValue(_actor: any, value: number): void;
+    _valueChanged(): void;
 }

--- a/packages/gnome-shell/src/ui/boxpointer.d.ts
+++ b/packages/gnome-shell/src/ui/boxpointer.d.ts
@@ -33,8 +33,8 @@ export class BoxPointer extends St.Widget {
     _sourceExtents: ReturnType<typeof Clutter.Actor.prototype.get_transformed_extents>;
     _workArea: ReturnType<typeof LayoutManager.prototype.getWorkAreaForMonitor>;
 
-    public bin: St.Bin;
-    public readonly arrowSide: St.Side;
+    bin: St.Bin;
+    readonly arrowSide: St.Side;
 
     /**
      * @param arrowSide side to draw the arrow on
@@ -43,49 +43,49 @@ export class BoxPointer extends St.Widget {
     constructor(arrowSide: St.Side, binProperties?: Partial<St.Bin.ConstructorProps>);
 
     /** @hidden */
-    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
+    _init(params?: Partial<St.Widget.ConstructorProps>): void;
 
     /**
      * @param arrowSide side to draw the arrow on
      * @param binProperties Properties to set on contained bin
      */
-    public _init(arrowSide: St.Side, binProperties?: Partial<St.Bin.ConstructorProps>): void;
+    _init(arrowSide: St.Side, binProperties?: Partial<St.Bin.ConstructorProps>): void;
 
-    public vfunc_captured_event(event: Clutter.Event): boolean;
+    vfunc_captured_event(event: Clutter.Event): boolean;
 
-    public vfunc_get_preferred_width(forHeight: number): [number, number];
+    vfunc_get_preferred_width(forHeight: number): [number, number];
 
-    public vfunc_get_preferred_height(forWidth: number): [number, number];
+    vfunc_get_preferred_height(forWidth: number): [number, number];
 
-    public vfunc_allocate(box: Clutter.ActorBox): void;
+    vfunc_allocate(box: Clutter.ActorBox): void;
 
-    public open(animate: boolean, onComplete: () => void): void;
+    open(animate: boolean, onComplete: () => void): void;
 
-    public close(animate: boolean, onComplete: () => void): void;
+    close(animate: boolean, onComplete: () => void): void;
 
-    public setPosition(sourceActor: Clutter.Actor, arrowAlignment: number): void;
+    setPosition(sourceActor: Clutter.Actor, arrowAlignment: number): void;
 
-    public setSourceAlignment(sourceAlignment: number): void;
+    setSourceAlignment(sourceAlignment: number): void;
 
     /**
      * @param origin Coordinate specifying middle of the arrow, along
      * the Y axis for St.Side.LEFT, St.Side.RIGHT from the top and X axis from
      * the left for St.Side.TOP and St.Side.BOTTOM.
      */
-    public setArrowOrigin(origin: number): void;
+    setArrowOrigin(origin: number): void;
 
     /**
      * @param actor an actor relative to which the arrow is positioned.
      * Differently from setPosition, this will not move the boxpointer itself,
      * on the arrow
      */
-    public setArrowActor(actor: St.Widget): void;
+    setArrowActor(actor: St.Widget): void;
 
-    public updateArrowSide(side: St.Side): void;
+    updateArrowSide(side: St.Side): void;
 
-    public getPadding(side: St.Side): number;
+    getPadding(side: St.Side): number;
 
-    public getArrowHeight(): number;
+    getArrowHeight(): number;
 
     _adjustAllocationForArrow(isWidth: boolean, minSize: number, naturalSize: number): void;
     _drawBorder(area: St.DrawingArea): void;

--- a/packages/gnome-shell/src/ui/boxpointer.d.ts
+++ b/packages/gnome-shell/src/ui/boxpointer.d.ts
@@ -20,18 +20,18 @@ export enum PopupAnimation {
  *
  */
 export class BoxPointer extends St.Widget {
-    protected _arrowSide: St.Side;
-    protected _userArrowSide: St.Side;
-    protected _arrowOrigin: number;
-    protected _arrowActor: St.Widget | null;
-    protected _border: St.DrawingArea;
-    protected _arrowAlignment: number;
-    protected _sourceAlignment: number;
-    protected _muteKeys: boolean;
-    protected _muteInput: boolean;
-    protected _sourceActor: Clutter.Actor | null;
-    protected _sourceExtents: ReturnType<typeof Clutter.Actor.prototype.get_transformed_extents>;
-    protected _workArea: ReturnType<typeof LayoutManager.prototype.getWorkAreaForMonitor>;
+    _arrowSide: St.Side;
+    _userArrowSide: St.Side;
+    _arrowOrigin: number;
+    _arrowActor: St.Widget | null;
+    _border: St.DrawingArea;
+    _arrowAlignment: number;
+    _sourceAlignment: number;
+    _muteKeys: boolean;
+    _muteInput: boolean;
+    _sourceActor: Clutter.Actor | null;
+    _sourceExtents: ReturnType<typeof Clutter.Actor.prototype.get_transformed_extents>;
+    _workArea: ReturnType<typeof LayoutManager.prototype.getWorkAreaForMonitor>;
 
     public bin: St.Bin;
     public readonly arrowSide: St.Side;
@@ -87,9 +87,9 @@ export class BoxPointer extends St.Widget {
 
     public getArrowHeight(): number;
 
-    protected _adjustAllocationForArrow(isWidth: boolean, minSize: number, naturalSize: number): void;
-    protected _drawBorder(area: St.DrawingArea): void;
-    protected _reposition(allocationBox: Clutter.ActorBox): void;
-    protected _calculateArrowSide(arrowSide: St.Side): St.Side;
-    protected _updateFlip(allocationBox: Clutter.ActorBox): void;
+    _adjustAllocationForArrow(isWidth: boolean, minSize: number, naturalSize: number): void;
+    _drawBorder(area: St.DrawingArea): void;
+    _reposition(allocationBox: Clutter.ActorBox): void;
+    _calculateArrowSide(arrowSide: St.Side): St.Side;
+    _updateFlip(allocationBox: Clutter.ActorBox): void;
 }

--- a/packages/gnome-shell/src/ui/calendar.d.ts
+++ b/packages/gnome-shell/src/ui/calendar.d.ts
@@ -26,10 +26,10 @@ declare function _getCalendarDayAbbreviation(dayNumber: number): string;
  * Abstraction for an appointment/event in a calendar
  */
 declare class CalendarEvent {
-    public id: string;
-    public date: Date;
-    public end: Date;
-    public summary: string;
+    id: string;
+    date: Date;
+    end: Date;
+    summary: string;
 
     constructor(id: string, date: Date, end: Date, summary: string);
 }
@@ -38,22 +38,22 @@ declare class CalendarEvent {
  * Interface for appointments/events - e.g. the contents of a calendar
  */
 declare abstract class EventSourceBase extends GObject.Object {
-    public abstract readonly isLoading: boolean;
-    public abstract readonly hasCalendars: boolean;
+    abstract readonly isLoading: boolean;
+    abstract readonly hasCalendars: boolean;
 
-    public destroy(): void;
-    public abstract requestRange(begin: Date, end: Date): void;
-    public abstract getEvents(begin: Date, end: Date): CalendarEvent[];
-    public abstract hasEvents(day: Date): boolean;
+    destroy(): void;
+    abstract requestRange(begin: Date, end: Date): void;
+    abstract getEvents(begin: Date, end: Date): CalendarEvent[];
+    abstract hasEvents(day: Date): boolean;
 }
 
 declare class EmptyEventSource extends EventSourceBase {
-    public readonly isLoading: boolean;
-    public readonly hasCalendars: boolean;
+    readonly isLoading: boolean;
+    readonly hasCalendars: boolean;
 
-    public requestRange(begin: Date, end: Date): void;
-    public getEvents(begin: Date, end: Date): CalendarEvent[];
-    public hasEvents(day: Date): boolean;
+    requestRange(begin: Date, end: Date): void;
+    getEvents(begin: Date, end: Date): CalendarEvent[];
+    hasEvents(day: Date): boolean;
 }
 
 declare const CalendarServerIface: GObject.Interface;
@@ -81,19 +81,19 @@ declare class DBusEventSource extends EventSourceBase {
     _initialized: boolean;
     _dbusProxy: Gio.DBusProxy;
 
-    public readonly isLoading: boolean;
-    public readonly hasCalendars: boolean;
+    readonly isLoading: boolean;
+    readonly hasCalendars: boolean;
 
     constructor();
-    public _init(): void;
+    _init(): void;
 
-    public requestRange(begin: Date, end: Date): void;
-    public getEvents(begin: Date, end: Date): CalendarEvent[];
-    public hasEvents(day: Date): boolean;
-    public destroy(): void;
-    public requestRange(begin: Date, end: Date): void;
-    public getEvents(begin: Date, end: Date): CalendarEvent[];
-    public hasEvents(day: Date): boolean;
+    requestRange(begin: Date, end: Date): void;
+    getEvents(begin: Date, end: Date): CalendarEvent[];
+    hasEvents(day: Date): boolean;
+    destroy(): void;
+    requestRange(begin: Date, end: Date): void;
+    getEvents(begin: Date, end: Date): CalendarEvent[];
+    hasEvents(day: Date): boolean;
 
     _initProxy(): Promise<void>;
     _resetCache(): void;
@@ -141,20 +141,20 @@ export class Calendar extends St.Widget {
 
     constructor();
     /** @hidden */
-    public _init(params?: Partial<St.Widget.ConstructorProps>): void;
-    public _init(): void;
+    _init(params?: Partial<St.Widget.ConstructorProps>): void;
+    _init(): void;
 
-    public setEventSource(eventSource: EventSourceBase): void;
+    setEventSource(eventSource: EventSourceBase): void;
 
     /**
      * Sets the calendar to show a specific date
      * @param date The date to show
      */
-    public setDate(date: Date): void;
+    setDate(date: Date): void;
 
-    public updateTimeZone(): void;
+    updateTimeZone(): void;
 
-    public vfunc_scroll_event(event: Clutter.ScrollEvent): boolean;
+    vfunc_scroll_event(event: Clutter.ScrollEvent): boolean;
 
     _buildHeader(): void;
     _onPrevMonthButtonClicked(): void;
@@ -171,7 +171,7 @@ declare class Placeholder extends St.BoxLayout {
 
     /** @hidden */
     override _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
-    public _init(): void;
+    _init(): void;
 }
 
 declare class DoNotDisturbSwitch extends Switch {
@@ -182,7 +182,7 @@ declare class DoNotDisturbSwitch extends Switch {
     override _init(config?: Partial<St.Bin.ConstructorProps>): void;
     /** @hidden */
     override _init(state: boolean): void;
-    public _init(): void;
+    _init(): void;
 }
 
 /**
@@ -202,7 +202,7 @@ export class CalendarMessageList extends St.Widget {
 
     /** @hidden */
     override _init(config?: Partial<St.Widget.ConstructorProps>): void;
-    public _init(): void;
+    _init(): void;
 
     maybeCollapseMessageGroupForEvent(event: Clutter.Event): boolean;
 }

--- a/packages/gnome-shell/src/ui/calendar.d.ts
+++ b/packages/gnome-shell/src/ui/calendar.d.ts
@@ -76,10 +76,10 @@ declare function _datesEqual(dateA: Date, dateB: Date): boolean;
 declare function _eventOverlapsInterval(e0: Date, e1: Date, i0: Date, i1: Date): boolean;
 
 declare class DBusEventSource extends EventSourceBase {
-    protected _events: Map<string, CalendarEvent>;
-    protected _isLoading: boolean;
-    protected _initialized: boolean;
-    protected _dbusProxy: Gio.DBusProxy;
+    _events: Map<string, CalendarEvent>;
+    _isLoading: boolean;
+    _initialized: boolean;
+    _dbusProxy: Gio.DBusProxy;
 
     public readonly isLoading: boolean;
     public readonly hasCalendars: boolean;
@@ -95,16 +95,16 @@ declare class DBusEventSource extends EventSourceBase {
     public getEvents(begin: Date, end: Date): CalendarEvent[];
     public hasEvents(day: Date): boolean;
 
-    protected _initProxy(): Promise<void>;
-    protected _resetCache(): void;
-    protected _removeMatching(uidPrefix: string): boolean;
-    protected _onNameAppeared(): void;
-    protected _onNameVanished(): void;
-    protected _onEventsAddedOrUpdated(dbusProxy: Gio.DBusProxy, nameOwner: string, argArray: any[][]): void;
-    protected _onEventsRemoved(dbusProxy: Gio.DBusProxy, nameOwner: string, argArray: any[][]): void;
-    protected _onClientDisappeared(dbusProxy: Gio.DBusProxy, nameOwner: string, argArray: string[]): void;
-    protected _loadEvents(forceReload: boolean): void;
-    protected _getFilteredEvents(begin: Date, end: Date): Generator<CalendarEvent, void, unknown>;
+    _initProxy(): Promise<void>;
+    _resetCache(): void;
+    _removeMatching(uidPrefix: string): boolean;
+    _onNameAppeared(): void;
+    _onNameVanished(): void;
+    _onEventsAddedOrUpdated(dbusProxy: Gio.DBusProxy, nameOwner: string, argArray: any[][]): void;
+    _onEventsRemoved(dbusProxy: Gio.DBusProxy, nameOwner: string, argArray: any[][]): void;
+    _onClientDisappeared(dbusProxy: Gio.DBusProxy, nameOwner: string, argArray: string[]): void;
+    _loadEvents(forceReload: boolean): void;
+    _getFilteredEvents(begin: Date, end: Date): Generator<CalendarEvent, void, unknown>;
 }
 
 /**
@@ -112,9 +112,9 @@ declare class DBusEventSource extends EventSourceBase {
  * @version 48
  */
 export class Calendar extends St.Widget {
-    protected _weekStart: number;
-    protected _settings: Gio.Settings;
-    protected _useWeekdate: boolean;
+    _weekStart: number;
+    _settings: Gio.Settings;
+    _useWeekdate: boolean;
 
     /**
      * Translators: The header displaying just the month name
@@ -122,7 +122,7 @@ export class Calendar extends St.Widget {
      * "%OB" is the new format specifier introduced in glibc 2.27,
      * in most cases you should not change it.
      */
-    protected _headerFormatWithoutYear: string;
+    _headerFormatWithoutYear: string;
 
     /**
      * Translators: The header displaying the month name and the year
@@ -133,11 +133,11 @@ export class Calendar extends St.Widget {
      * in most cases you should not use the old "%B" here unless you
      * absolutely know what you are doing.
      */
-    protected _headerFormat: string;
+    _headerFormat: string;
 
-    protected _selectedDate: Date;
+    _selectedDate: Date;
 
-    protected _shouldDateGrabFocus: boolean;
+    _shouldDateGrabFocus: boolean;
 
     constructor();
     /** @hidden */
@@ -156,18 +156,18 @@ export class Calendar extends St.Widget {
 
     public vfunc_scroll_event(event: Clutter.ScrollEvent): boolean;
 
-    protected _buildHeader(): void;
-    protected _onPrevMonthButtonClicked(): void;
-    protected _onNextMonthButtonClicked(): void;
-    protected _onSettingsChange(): void;
-    protected _rebuildCalendar(): void;
-    protected _update(): void;
+    _buildHeader(): void;
+    _onPrevMonthButtonClicked(): void;
+    _onNextMonthButtonClicked(): void;
+    _onSettingsChange(): void;
+    _rebuildCalendar(): void;
+    _update(): void;
 }
 
 declare class Placeholder extends St.BoxLayout {
-    protected _date: Date;
-    protected _icon: St.Icon;
-    protected _label: St.Label;
+    _date: Date;
+    _icon: St.Icon;
+    _label: St.Label;
 
     /** @hidden */
     override _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
@@ -175,7 +175,7 @@ declare class Placeholder extends St.BoxLayout {
 }
 
 declare class DoNotDisturbSwitch extends Switch {
-    protected _settings: Gio.Settings;
+    _settings: Gio.Settings;
 
     constructor();
     /** @hidden */

--- a/packages/gnome-shell/src/ui/checkBox.d.ts
+++ b/packages/gnome-shell/src/ui/checkBox.d.ts
@@ -1,8 +1,8 @@
 import type St from '@girs/st-16';
 
 export class CheckBox extends St.Button {
-    protected _box: St.Bin;
-    protected _label: St.Label;
+    _box: St.Bin;
+    _label: St.Label;
 
     constructor(label?: string);
     /** @hidden */

--- a/packages/gnome-shell/src/ui/checkBox.d.ts
+++ b/packages/gnome-shell/src/ui/checkBox.d.ts
@@ -6,9 +6,9 @@ export class CheckBox extends St.Button {
 
     constructor(label?: string);
     /** @hidden */
-    public _init(params?: Partial<St.Button.ConstructorProps>): void;
-    public _init(label?: string): void;
+    _init(params?: Partial<St.Button.ConstructorProps>): void;
+    _init(label?: string): void;
 
-    public setLabel(label: string): void;
-    public getLabelActor(): St.Label;
+    setLabel(label: string): void;
+    getLabelActor(): St.Label;
 }

--- a/packages/gnome-shell/src/ui/closeDialog.d.ts
+++ b/packages/gnome-shell/src/ui/closeDialog.d.ts
@@ -9,10 +9,10 @@ export class CloseDialog extends GObject.Object {
     _tracked: boolean;
     _timeoutId: number;
 
-    public window: Meta.Window;
+    window: Meta.Window;
 
-    public constructor(window: Meta.Window);
-    public _init(window: Meta.Window): void;
+    constructor(window: Meta.Window);
+    _init(window: Meta.Window): void;
 
     _createDialogContent(): MessageDialogContent;
     _updateScale(): void;
@@ -23,7 +23,7 @@ export class CloseDialog extends GObject.Object {
     _onClose(): void;
     _onFocusChanged(): void;
 
-    public vfunc_show(): void;
-    public vfunc_hide(): void;
-    public vfunc_focus(): void;
+    vfunc_show(): void;
+    vfunc_hide(): void;
+    vfunc_focus(): void;
 }

--- a/packages/gnome-shell/src/ui/closeDialog.d.ts
+++ b/packages/gnome-shell/src/ui/closeDialog.d.ts
@@ -4,24 +4,24 @@ import type Meta from '@girs/meta-16';
 import { Dialog, MessageDialogContent } from './dialog.js';
 
 export class CloseDialog extends GObject.Object {
-    protected _window: Meta.Window;
-    protected _dialog: Dialog | null;
-    protected _tracked: boolean;
-    protected _timeoutId: number;
+    _window: Meta.Window;
+    _dialog: Dialog | null;
+    _tracked: boolean;
+    _timeoutId: number;
 
     public window: Meta.Window;
 
     public constructor(window: Meta.Window);
     public _init(window: Meta.Window): void;
 
-    protected _createDialogContent(): MessageDialogContent;
-    protected _updateScale(): void;
-    protected _initDialog(): void;
-    protected _addWindowEffect(): void;
-    protected _removeWindowEffect(): void;
-    protected _onWait(): void;
-    protected _onClose(): void;
-    protected _onFocusChanged(): void;
+    _createDialogContent(): MessageDialogContent;
+    _updateScale(): void;
+    _initDialog(): void;
+    _addWindowEffect(): void;
+    _removeWindowEffect(): void;
+    _onWait(): void;
+    _onClose(): void;
+    _onFocusChanged(): void;
 
     public vfunc_show(): void;
     public vfunc_hide(): void;

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -20,9 +20,9 @@ export interface ButtonInfo {
  * @version 48
  */
 export class Dialog extends St.Widget {
-    protected _parentActor: St.Widget;
-    protected _dialog: St.BoxLayout;
-    protected _initialKeyFocus: St.Widget;
+    _parentActor: St.Widget;
+    _dialog: St.BoxLayout;
+    _initialKeyFocus: St.Widget;
 
     public contentLayout: St.BoxLayout;
     public buttonLayout: St.Widget;
@@ -34,9 +34,9 @@ export class Dialog extends St.Widget {
     public addButton(buttonInfo: ButtonInfo): St.Button;
     public clearButtons(): void;
 
-    protected _createDialog(): void;
-    protected _onDestroy(): void;
-    protected _setInitialKeyFocus(actor: St.Widget): void;
+    _createDialog(): void;
+    _onDestroy(): void;
+    _setInitialKeyFocus(actor: St.Widget): void;
 }
 
 /**
@@ -60,8 +60,8 @@ export class MessageDialogContent extends St.BoxLayout {
     constructor(params: Partial<MessageDialogContent.ConstructorProps>);
     public _init(params: Partial<MessageDialogContent.ConstructorProps>): void;
 
-    protected _onDestroy(): void;
-    protected _updateTitleStyle(): void | false;
+    _onDestroy(): void;
+    _updateTitleStyle(): void | false;
 }
 
 /**
@@ -79,8 +79,8 @@ export namespace ListSection {
  * @version 48
  */
 export class ListSection extends St.BoxLayout {
-    protected _listScrollView: St.ScrollView;
-    protected _title: St.Label;
+    _listScrollView: St.ScrollView;
+    _title: St.Label;
 
     public list: St.BoxLayout;
     public title: string;
@@ -106,8 +106,8 @@ export namespace ListSectionItem {
  * @version 48
  */
 export class ListSectionItem extends St.BoxLayout {
-    protected _iconActorBin: St.Bin;
-    protected _title: St.Label;
+    _iconActorBin: St.Bin;
+    _title: St.Label;
 
     public title: string;
     public description: string;

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -24,15 +24,15 @@ export class Dialog extends St.Widget {
     _dialog: St.BoxLayout;
     _initialKeyFocus: St.Widget;
 
-    public contentLayout: St.BoxLayout;
-    public buttonLayout: St.Widget;
-    public readonly initialKeyFocus: St.Widget;
+    contentLayout: St.BoxLayout;
+    buttonLayout: St.Widget;
+    readonly initialKeyFocus: St.Widget;
 
-    public _init(parentActor: St.Widget, styleClass?: string | null): void;
-    public makeInactive(): void;
-    public vfunc_event(event: Clutter.Event): boolean;
-    public addButton(buttonInfo: ButtonInfo): St.Button;
-    public clearButtons(): void;
+    _init(parentActor: St.Widget, styleClass?: string | null): void;
+    makeInactive(): void;
+    vfunc_event(event: Clutter.Event): boolean;
+    addButton(buttonInfo: ButtonInfo): St.Button;
+    clearButtons(): void;
 
     _createDialog(): void;
     _onDestroy(): void;
@@ -54,11 +54,11 @@ export namespace MessageDialogContent {
  * @version 48
  */
 export class MessageDialogContent extends St.BoxLayout {
-    public title: string;
-    public description: string;
+    title: string;
+    description: string;
 
     constructor(params: Partial<MessageDialogContent.ConstructorProps>);
-    public _init(params: Partial<MessageDialogContent.ConstructorProps>): void;
+    _init(params: Partial<MessageDialogContent.ConstructorProps>): void;
 
     _onDestroy(): void;
     _updateTitleStyle(): void | false;
@@ -82,11 +82,11 @@ export class ListSection extends St.BoxLayout {
     _listScrollView: St.ScrollView;
     _title: St.Label;
 
-    public list: St.BoxLayout;
-    public title: string;
+    list: St.BoxLayout;
+    title: string;
 
     constructor(params: Partial<ListSection.ConstructorProps>);
-    public _init(params: Partial<ListSection.ConstructorProps>): void;
+    _init(params: Partial<ListSection.ConstructorProps>): void;
 }
 
 /**
@@ -109,13 +109,13 @@ export class ListSectionItem extends St.BoxLayout {
     _iconActorBin: St.Bin;
     _title: St.Label;
 
-    public title: string;
-    public description: string;
-    public iconActor: St.Widget;
+    title: string;
+    description: string;
+    iconActor: St.Widget;
 
     constructor(params: { style_class?: string | null });
 
     /** @hidden Defined to resolve version conflicts */
-    public _init(config?: Partial<ListSectionItem.ConstructorProps>): void;
-    public _init(params: { style_class?: string | null }): void;
+    _init(config?: Partial<ListSectionItem.ConstructorProps>): void;
+    _init(params: { style_class?: string | null }): void;
 }

--- a/packages/gnome-shell/src/ui/dnd.d.ts
+++ b/packages/gnome-shell/src/ui/dnd.d.ts
@@ -38,7 +38,7 @@ declare namespace _Draggable {
 }
 
 declare class _Draggable extends EventEmitter {
-    public actor: Clutter.Actor;
+    actor: Clutter.Actor;
 
     constructor(actor: Clutter.Actor, params: Partial<_Draggable.ConstructorProps>);
 
@@ -50,7 +50,7 @@ declare class _Draggable extends EventEmitter {
      * actors for other purposes (for example if you're using
      * PopupMenu.ignoreRelease())
      */
-    public fakeRelease(): void;
+    fakeRelease(): void;
 
     /**
      * startDrag:
@@ -64,7 +64,7 @@ declare class _Draggable extends EventEmitter {
      * This function is useful to call if you've specified manualMode
      * for the draggable.
      */
-    public startDrag(stageX: number, stageY: number, time: number, sequence?: Clutter.EventSequence, device?: Clutter.InputDevice): void;
+    startDrag(stageX: number, stageY: number, time: number, sequence?: Clutter.EventSequence, device?: Clutter.InputDevice): void;
 
     _onButtonPress(actor: Clutter.Actor, event: Clutter.Event): boolean;
     _onTouchEvent(actor: Clutter.Actor, event: Clutter.Event): boolean;

--- a/packages/gnome-shell/src/ui/dnd.d.ts
+++ b/packages/gnome-shell/src/ui/dnd.d.ts
@@ -66,30 +66,30 @@ declare class _Draggable extends EventEmitter {
      */
     public startDrag(stageX: number, stageY: number, time: number, sequence?: Clutter.EventSequence, device?: Clutter.InputDevice): void;
 
-    protected _onButtonPress(actor: Clutter.Actor, event: Clutter.Event): boolean;
-    protected _onTouchEvent(actor: Clutter.Actor, event: Clutter.Event): boolean;
-    protected _grabDevice(actor: Clutter.Actor, pointer: Clutter.InputDevice, touchSequence: Clutter.EventSequence): boolean;
-    protected _ungrabDevice(): void;
-    protected _grabActor(device: Clutter.InputDevice, touchSequence: Clutter.EventSequence): void;
-    protected _ungrabActor(): void;
-    protected _grabEvents(device: Clutter.InputDevice, touchSequence: Clutter.EventSequence): void;
-    protected _ungrabEvents(): void;
-    protected _eventIsRelease(event: Clutter.Event): boolean;
-    protected _onEvent(actor: Clutter.Actor, event: Clutter.Event): boolean;
-    protected _updateActorPosition(origScale: number, origDragOffsetX: number, origDragOffsetY: number, transX: number, transY: number): void;
-    protected _maybeStartDrag(event: Clutter.Event): void;
-    protected _pickTargetActor(): Clutter.Actor;
-    protected _updateDragHover(): void;
-    protected _queueUpdateDragHover(): void;
-    protected _updateDragPosition(event: Clutter.Event): void;
-    protected _dragActorDropped(event: Clutter.Event): void;
-    protected _getRestoreLocation(): [number, number, number];
-    protected _cancelDrag(eventTime: number): void;
-    protected _restoreDragActor(eventTime: number): void;
-    protected _animateDragEnd(eventTime: number, params: { opacity: number; mode: Clutter.AnimationMode; onComplete: () => void }): void;
-    protected _finishAnimation(): void;
-    protected _onAnimationComplete(dragActor: Clutter.Actor, eventTime: number): void;
-    protected _dragComplete(): void;
+    _onButtonPress(actor: Clutter.Actor, event: Clutter.Event): boolean;
+    _onTouchEvent(actor: Clutter.Actor, event: Clutter.Event): boolean;
+    _grabDevice(actor: Clutter.Actor, pointer: Clutter.InputDevice, touchSequence: Clutter.EventSequence): boolean;
+    _ungrabDevice(): void;
+    _grabActor(device: Clutter.InputDevice, touchSequence: Clutter.EventSequence): void;
+    _ungrabActor(): void;
+    _grabEvents(device: Clutter.InputDevice, touchSequence: Clutter.EventSequence): void;
+    _ungrabEvents(): void;
+    _eventIsRelease(event: Clutter.Event): boolean;
+    _onEvent(actor: Clutter.Actor, event: Clutter.Event): boolean;
+    _updateActorPosition(origScale: number, origDragOffsetX: number, origDragOffsetY: number, transX: number, transY: number): void;
+    _maybeStartDrag(event: Clutter.Event): void;
+    _pickTargetActor(): Clutter.Actor;
+    _updateDragHover(): void;
+    _queueUpdateDragHover(): void;
+    _updateDragPosition(event: Clutter.Event): void;
+    _dragActorDropped(event: Clutter.Event): void;
+    _getRestoreLocation(): [number, number, number];
+    _cancelDrag(eventTime: number): void;
+    _restoreDragActor(eventTime: number): void;
+    _animateDragEnd(eventTime: number, params: { opacity: number; mode: Clutter.AnimationMode; onComplete: () => void }): void;
+    _finishAnimation(): void;
+    _onAnimationComplete(dragActor: Clutter.Actor, eventTime: number): void;
+    _dragComplete(): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/iconGrid.d.ts
+++ b/packages/gnome-shell/src/ui/iconGrid.d.ts
@@ -17,7 +17,7 @@ export class BaseIcon extends Shell.SquareBin {
     public icon: St.Icon | null;
     public label: St.Label | null;
 
-    protected _setSizeManually?: boolean;
+    _setSizeManually?: boolean;
 
     constructor(label: string, params?: Partial<BaseIcon.ConstructorProps>);
 
@@ -45,7 +45,7 @@ export class IconGrid extends St.Viewport {
     public readonly nPages: number;
     public readonly itemsPerPage: number;
 
-    protected _currentPage: number;
+    _currentPage: number;
 
     constructor(layoutParams?: Partial<IconGrid.ConstructorProps>);
 
@@ -53,11 +53,11 @@ export class IconGrid extends St.Viewport {
     public _init(params?: Partial<St.Viewport.ConstructorProps>): void;
     public _init(layoutParams?: IconGrid.ConstructorProps): void;
 
-    protected _childAdded(grid: IconGrid, child: St.Widget): void;
-    protected _ensureItemIsVisible(item: St.Widget): void;
-    protected _setGridMode(modeIndex: number): void;
-    protected _findBestModeForSize(width: number, height: number): void;
-    protected _childRemoved(grid: IconGrid, child: St.Widget): void;
+    _childAdded(grid: IconGrid, child: St.Widget): void;
+    _ensureItemIsVisible(item: St.Widget): void;
+    _setGridMode(modeIndex: number): void;
+    _findBestModeForSize(width: number, height: number): void;
+    _childRemoved(grid: IconGrid, child: St.Widget): void;
 
     /**
      * addItem:

--- a/packages/gnome-shell/src/ui/iconGrid.d.ts
+++ b/packages/gnome-shell/src/ui/iconGrid.d.ts
@@ -13,16 +13,16 @@ export namespace BaseIcon {
 }
 
 export class BaseIcon extends Shell.SquareBin {
-    public createIcon: any | null;
-    public icon: St.Icon | null;
-    public label: St.Label | null;
+    createIcon: any | null;
+    icon: St.Icon | null;
+    label: St.Label | null;
 
     _setSizeManually?: boolean;
 
     constructor(label: string, params?: Partial<BaseIcon.ConstructorProps>);
 
-    public _init(params?: Partial<Shell.SquareBin.ConstructorProps>): void;
-    public _init(label: string, params?: Partial<BaseIcon.ConstructorProps>): void;
+    _init(params?: Partial<Shell.SquareBin.ConstructorProps>): void;
+    _init(label: string, params?: Partial<BaseIcon.ConstructorProps>): void;
 }
 
 export namespace IconGrid {
@@ -41,17 +41,17 @@ export namespace IconGrid {
 }
 
 export class IconGrid extends St.Viewport {
-    public currentPage: number;
-    public readonly nPages: number;
-    public readonly itemsPerPage: number;
+    currentPage: number;
+    readonly nPages: number;
+    readonly itemsPerPage: number;
 
     _currentPage: number;
 
     constructor(layoutParams?: Partial<IconGrid.ConstructorProps>);
 
     /** @hidden */
-    public _init(params?: Partial<St.Viewport.ConstructorProps>): void;
-    public _init(layoutParams?: IconGrid.ConstructorProps): void;
+    _init(params?: Partial<St.Viewport.ConstructorProps>): void;
+    _init(layoutParams?: IconGrid.ConstructorProps): void;
 
     _childAdded(grid: IconGrid, child: St.Widget): void;
     _ensureItemIsVisible(item: St.Widget): void;
@@ -73,7 +73,7 @@ export class IconGrid extends St.Viewport {
      * @page must be a number between 0 and the number of pages.
      * Adding to the page after next will create a new page.
      */
-    public addItem(item: Clutter.Actor, page?: number, index?: number): void;
+    addItem(item: Clutter.Actor, page?: number, index?: number): void;
 
     /**
      * appendItem:

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -47,18 +47,18 @@ export class MonitorConstraint extends Clutter.Constraint {
     _index: number;
     _workArea: boolean;
 
-    public primary: boolean;
-    public index: number;
-    public workArea: boolean;
+    primary: boolean;
+    index: number;
+    workArea: boolean;
 
     constructor(props: Partial<MonitorConstraint.ConstructorProps>);
 
     /** @hidden */
-    public _init(props: Partial<MonitorConstraint.ConstructorProps>): void;
-    public _init(): void;
+    _init(props: Partial<MonitorConstraint.ConstructorProps>): void;
+    _init(): void;
 
-    public vfunc_set_actor(actor: Clutter.Actor): void;
-    public vfunc_update_allocation(actor: Clutter.Actor, actorBox: Clutter.ActorBox): void;
+    vfunc_set_actor(actor: Clutter.Actor): void;
+    vfunc_update_allocation(actor: Clutter.Actor, actorBox: Clutter.ActorBox): void;
 }
 
 /**
@@ -66,13 +66,13 @@ export class MonitorConstraint extends Clutter.Constraint {
  * @version 48
  */
 declare class Monitor {
-    public index: number;
-    public geometryScale: number;
-    public x: number;
-    public y: number;
-    public width: number;
-    public height: number;
-    public readonly inFullscreen: boolean;
+    index: number;
+    geometryScale: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    readonly inFullscreen: boolean;
 
     constructor(index: number, geometry: Geometry, geometryScale: number);
 }
@@ -82,11 +82,11 @@ declare class Monitor {
  * @version 48
  */
 declare class UiActor extends St.Widget {
-    public constructor(props?: Partial<St.Widget.ConstructorProps>);
-    public _init(props?: Partial<St.Widget.ConstructorProps>): void;
+    constructor(props?: Partial<St.Widget.ConstructorProps>);
+    _init(props?: Partial<St.Widget.ConstructorProps>): void;
 
-    public vfunc_get_preferred_width(_forHeight: number): [number, number];
-    public vfunc_get_preferred_height(_forWidth: number): [number, number];
+    vfunc_get_preferred_width(_forHeight: number): [number, number];
+    vfunc_get_preferred_height(_forWidth: number): [number, number];
 }
 
 /**
@@ -97,11 +97,11 @@ declare class ScreenTransition extends Clutter.Actor {
     constructor();
 
     /** @hidden */
-    public _init(params?: Partial<Clutter.Actor.ConstructorProps>): void;
-    public _init(): void;
+    _init(params?: Partial<Clutter.Actor.ConstructorProps>): void;
+    _init(): void;
 
-    public vfunc_hide(): void;
-    public run(): void;
+    vfunc_hide(): void;
+    run(): void;
 }
 
 /**
@@ -121,12 +121,12 @@ declare class HotCorner extends Clutter.Actor {
 
     constructor(layoutManager: LayoutManager, monitor: Monitor, x: number, y: number);
 
-    public _init(props?: Partial<Clutter.Actor.ConstructorProps>): void;
-    public _init(layoutManager: LayoutManager, monitor: Monitor, x: number, y: number): void;
+    _init(props?: Partial<Clutter.Actor.ConstructorProps>): void;
+    _init(layoutManager: LayoutManager, monitor: Monitor, x: number, y: number): void;
 
-    public setBarrierSize(size: number): void;
-    public handleDragOver(source: any, actor: any, x: number, y: number, time: number): DragMotionResult;
-    public vfunc_leave_event(event: Clutter.Event): boolean;
+    setBarrierSize(size: number): void;
+    handleDragOver(source: any, actor: any, x: number, y: number, time: number): DragMotionResult;
+    vfunc_leave_event(event: Clutter.Event): boolean;
 
     _setupFallbackCornerIfNeeded(layoutManager: LayoutManager): void;
     _onDestroy(): void;
@@ -162,32 +162,32 @@ export class LayoutManager extends GObject.Object {
     _pendingLoadBackground: boolean;
     _systemBackground: SystemBackground;
 
-    public readonly _startingUp: boolean;
-    public monitors: Monitor[];
-    public primaryMonitor: Monitor | null;
-    public primaryIndex: number;
-    public hotCorners: HotCorner[];
-    public uiGroup: UiActor;
-    public overviewGroup: St.Widget;
-    public screenShieldGroup: St.Widget;
-    public panelBox: St.BoxLayout;
-    public modalDialogGroup: St.Widget;
-    public keyboardBox: St.BoxLayout;
-    public screenshotUIGroup: St.Widget;
-    public dummyCursor: St.Widget;
-    public screenTransition: ScreenTransition;
-    public readonly currentMonitor: Monitor | undefined;
-    public readonly keyboardMonitor: Monitor | undefined;
-    public readonly focusIndex: number;
-    public readonly focusMonitor: Monitor | undefined;
-    public keyboardIndex: number;
+    readonly _startingUp: boolean;
+    monitors: Monitor[];
+    primaryMonitor: Monitor | null;
+    primaryIndex: number;
+    hotCorners: HotCorner[];
+    uiGroup: UiActor;
+    overviewGroup: St.Widget;
+    screenShieldGroup: St.Widget;
+    panelBox: St.BoxLayout;
+    modalDialogGroup: St.Widget;
+    keyboardBox: St.BoxLayout;
+    screenshotUIGroup: St.Widget;
+    dummyCursor: St.Widget;
+    screenTransition: ScreenTransition;
+    readonly currentMonitor: Monitor | undefined;
+    readonly keyboardMonitor: Monitor | undefined;
+    readonly focusIndex: number;
+    readonly focusMonitor: Monitor | undefined;
+    keyboardIndex: number;
 
     constructor();
-    public _init(): void;
+    _init(): void;
 
-    public init(): void;
-    public showOverview(): void;
-    public hideOverview(): void;
+    init(): void;
+    showOverview(): void;
+    hideOverview(): void;
 
     /**
      * setDummyCursorGeometry:
@@ -205,7 +205,7 @@ export class LayoutManager extends GObject.Object {
      * @param width
      * @param height
      */
-    public setDummyCursorGeometry(x: number, y: number, width: number, height: number): void;
+    setDummyCursorGeometry(x: number, y: number, width: number, height: number): void;
 
     /**
      * Adds `actor` to the chrome, and (unless `affectsInputRegion` in
@@ -226,14 +226,14 @@ export class LayoutManager extends GObject.Object {
      * @param actor An actor to add to the chrome
      * @param params Additional params
      */
-    public addChrome(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
+    addChrome(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
 
     /**
      * Like {@link addChrome()}, but adds `actor` above all windows, including popups.
      * @param actor An actor to add to the chrome
      * @param params Additional params
      */
-    public addTopChrome(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
+    addTopChrome(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
 
     /**
      * Tells the chrome to track `actor`. This can be used to extend the
@@ -246,33 +246,33 @@ export class LayoutManager extends GObject.Object {
      * @param actor a descendant of the chrome to begin tracking
      * @param params parameters describing how to track `actor`
      */
-    public trackChrome(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
+    trackChrome(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
 
     /**
      * Undoes the effect of {@link trackChrome()}
      * `params` is `false`) removes it from the input region.
      * @param actor An actor previously tracked via {@link trackChrome()}
      */
-    public untrackChrome(actor: Clutter.Actor): void;
+    untrackChrome(actor: Clutter.Actor): void;
 
     /**
      * Removes `actor` from the chrome
      * @param actor An actor previously added via {@link addChrome()}
      */
-    public removeChrome(actor: Clutter.Actor): void;
+    removeChrome(actor: Clutter.Actor): void;
 
-    public getWorkAreaForMonitor(monitorIndex: number): Mtk.Rectangle;
+    getWorkAreaForMonitor(monitorIndex: number): Mtk.Rectangle;
 
     /**
      * This call guarantees that we return some monitor to simplify usage of it
      * In practice all tracked actors should be visible on some monitor anyway
      * @param actor
      */
-    public findIndexForActor(actor: Clutter.Actor): number;
+    findIndexForActor(actor: Clutter.Actor): number;
 
-    public findMonitorForActor(actor: Clutter.Actor): Monitor | undefined;
+    findMonitorForActor(actor: Clutter.Actor): Monitor | undefined;
 
-    public modalEnded(): void;
+    modalEnded(): void;
 
     _sessionUpdated(): void;
     _updateMonitors(): void;
@@ -338,10 +338,10 @@ declare class PressureBarrier extends EventEmitter {
 
     constructor(threshold: number, timeout: number, actionMode: Shell.ActionMode);
 
-    public addBarrier(barrier: Meta.Barrier): void;
-    public removeBarrier(barrier: Meta.Barrier): void;
-    public destroy(): void;
-    public setEventFilter(filter: any): void;
+    addBarrier(barrier: Meta.Barrier): void;
+    removeBarrier(barrier: Meta.Barrier): void;
+    destroy(): void;
+    setEventFilter(filter: any): void;
 
     _disconnectBarrier(barrier: Meta.Barrier): void;
     _reset(): void;

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -43,9 +43,9 @@ export namespace MonitorConstraint {
  * @version 48
  */
 export class MonitorConstraint extends Clutter.Constraint {
-    protected _primary: boolean;
-    protected _index: number;
-    protected _workArea: boolean;
+    _primary: boolean;
+    _index: number;
+    _workArea: boolean;
 
     public primary: boolean;
     public index: number;
@@ -112,12 +112,12 @@ declare class ScreenTransition extends Clutter.Actor {
  * @version 48
  */
 declare class HotCorner extends Clutter.Actor {
-    protected _entered: boolean;
-    protected _monitor: Monitor;
-    protected _x: number;
-    protected _y: number;
-    protected _pressureBarrier: PressureBarrier;
-    protected _ripples: Ripples;
+    _entered: boolean;
+    _monitor: Monitor;
+    _x: number;
+    _y: number;
+    _pressureBarrier: PressureBarrier;
+    _ripples: Ripples;
 
     constructor(layoutManager: LayoutManager, monitor: Monitor, x: number, y: number);
 
@@ -128,11 +128,11 @@ declare class HotCorner extends Clutter.Actor {
     public handleDragOver(source: any, actor: any, x: number, y: number, time: number): DragMotionResult;
     public vfunc_leave_event(event: Clutter.Event): boolean;
 
-    protected _setupFallbackCornerIfNeeded(layoutManager: LayoutManager): void;
-    protected _onDestroy(): void;
-    protected _toggleOverview(): void;
-    protected _onCornerEntered(): void;
-    protected _onCornerLeft(actor: Clutter.Actor, event: Clutter.Event): void;
+    _setupFallbackCornerIfNeeded(layoutManager: LayoutManager): void;
+    _onDestroy(): void;
+    _toggleOverview(): void;
+    _onCornerEntered(): void;
+    _onCornerLeft(actor: Clutter.Actor, event: Clutter.Event): void;
 }
 
 /**
@@ -150,17 +150,17 @@ export interface TrackedActors {
  * @version 48
  */
 export class LayoutManager extends GObject.Object {
-    protected _rtl: boolean;
-    protected _keyboardIndex: number;
-    protected _rightPanelBarrier: Meta.Barrier | null;
-    protected _inOverview: boolean;
-    protected _updateRegionIdle: number;
-    protected _trackedActors: TrackedActors[];
-    protected _keyboardHeightNotifyId: number;
-    protected _backgroundGroup: Meta.BackgroundGroup;
-    protected _interfaceSettings: Gio.Settings;
-    protected _pendingLoadBackground: boolean;
-    protected _systemBackground: SystemBackground;
+    _rtl: boolean;
+    _keyboardIndex: number;
+    _rightPanelBarrier: Meta.Barrier | null;
+    _inOverview: boolean;
+    _updateRegionIdle: number;
+    _trackedActors: TrackedActors[];
+    _keyboardHeightNotifyId: number;
+    _backgroundGroup: Meta.BackgroundGroup;
+    _interfaceSettings: Gio.Settings;
+    _pendingLoadBackground: boolean;
+    _systemBackground: SystemBackground;
 
     public readonly _startingUp: boolean;
     public monitors: Monitor[];
@@ -274,21 +274,21 @@ export class LayoutManager extends GObject.Object {
 
     public modalEnded(): void;
 
-    protected _sessionUpdated(): void;
-    protected _updateMonitors(): void;
-    protected _updateHotCorners(): void;
-    protected _addBackgroundMenu(bgManager: BackgroundManager): void;
-    protected _createBackgroundManager(monitorIndex: number): BackgroundManager;
-    protected _showSecondaryBackgrounds(): void;
-    protected _waitLoaded(bgManager: BackgroundManager): void;
-    protected _updateBackgrounds(): Promise<void>;
-    protected _updateKeyboardBox(): void;
-    protected _updateBoxes(): void;
-    protected _panelBoxChanged(): void;
-    protected _updatePanelBarrier(): void;
-    protected _monitorsChanged(): void;
-    protected _isAboveOrBelowPrimary(monitor: Monitor): boolean;
-    protected _loadBackground(): void;
+    _sessionUpdated(): void;
+    _updateMonitors(): void;
+    _updateHotCorners(): void;
+    _addBackgroundMenu(bgManager: BackgroundManager): void;
+    _createBackgroundManager(monitorIndex: number): BackgroundManager;
+    _showSecondaryBackgrounds(): void;
+    _waitLoaded(bgManager: BackgroundManager): void;
+    _updateBackgrounds(): Promise<void>;
+    _updateKeyboardBox(): void;
+    _updateBoxes(): void;
+    _panelBoxChanged(): void;
+    _updatePanelBarrier(): void;
+    _monitorsChanged(): void;
+    _isAboveOrBelowPrimary(monitor: Monitor): boolean;
+    _loadBackground(): void;
     /**
      * Startup Animations
      *
@@ -305,20 +305,20 @@ export class LayoutManager extends GObject.Object {
      * When starting a normal user session, we want to grow it out of the middle
      * of the screen.
      */
-    protected _prepareStartupAnimation(): Promise<void>;
-    protected _startupAnimation(): Promise<void>;
-    protected _startupAnimationGreeter(): Promise<void>;
-    protected _startupAnimationSession(): Promise<void>;
-    protected _startupAnimationComplete(): void;
-    protected _findActor(actor: Clutter.Actor): number;
-    protected _trackActor(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
-    protected _untrackActor(actor: Clutter.Actor): void;
-    protected _updateActorVisibility(actorData: any): void;
-    protected _updateVisibility(): void;
-    protected _queueUpdateRegions(): void;
-    protected _updateFullscreen(): void;
-    protected _windowsRestacked(): void;
-    protected _updateRegions(): boolean;
+    _prepareStartupAnimation(): Promise<void>;
+    _startupAnimation(): Promise<void>;
+    _startupAnimationGreeter(): Promise<void>;
+    _startupAnimationSession(): Promise<void>;
+    _startupAnimationComplete(): void;
+    _findActor(actor: Clutter.Actor): number;
+    _trackActor(actor: Clutter.Actor, params?: Partial<TrackedActors>): void;
+    _untrackActor(actor: Clutter.Actor): void;
+    _updateActorVisibility(actorData: any): void;
+    _updateVisibility(): void;
+    _queueUpdateRegions(): void;
+    _updateFullscreen(): void;
+    _windowsRestacked(): void;
+    _updateRegions(): boolean;
 }
 
 /**
@@ -326,15 +326,15 @@ export class LayoutManager extends GObject.Object {
  * @version 48
  */
 declare class PressureBarrier extends EventEmitter {
-    protected _threshold: number;
-    protected _timeout: number;
-    protected _actionMode: Shell.ActionMode;
-    protected _barriers: any[];
-    protected _eventFilter: any | null;
-    protected _isTriggered: boolean;
-    protected _barrierEvents: any[];
-    protected _currentPressure: number;
-    protected _lastTime: number;
+    _threshold: number;
+    _timeout: number;
+    _actionMode: Shell.ActionMode;
+    _barriers: any[];
+    _eventFilter: any | null;
+    _isTriggered: boolean;
+    _barrierEvents: any[];
+    _currentPressure: number;
+    _lastTime: number;
 
     constructor(threshold: number, timeout: number, actionMode: Shell.ActionMode);
 
@@ -343,13 +343,13 @@ declare class PressureBarrier extends EventEmitter {
     public destroy(): void;
     public setEventFilter(filter: any): void;
 
-    protected _disconnectBarrier(barrier: Meta.Barrier): void;
-    protected _reset(): void;
-    protected _isHorizontal(barrier: Meta.Barrier): boolean;
-    protected _getDistanceAcrossBarrier(barrier: Meta.Barrier, event: any): number;
-    protected _getDistanceAlongBarrier(barrier: Meta.Barrier, event: any): number;
-    protected _trimBarrierEvents(): void;
-    protected _onBarrierLeft(barrier: Meta.Barrier, event: any): void;
-    protected _trigger(): void;
-    protected _onBarrierHit(barrier: Meta.Barrier, event: any): void;
+    _disconnectBarrier(barrier: Meta.Barrier): void;
+    _reset(): void;
+    _isHorizontal(barrier: Meta.Barrier): boolean;
+    _getDistanceAcrossBarrier(barrier: Meta.Barrier, event: any): number;
+    _getDistanceAlongBarrier(barrier: Meta.Barrier, event: any): number;
+    _trimBarrierEvents(): void;
+    _onBarrierLeft(barrier: Meta.Barrier, event: any): void;
+    _trigger(): void;
+    _onBarrierHit(barrier: Meta.Barrier, event: any): void;
 }

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -28,8 +28,8 @@ export namespace RadialShaderEffect {
  * @version 48
  */
 export class RadialShaderEffect extends Shell.GLSLEffect {
-    protected _brightness: number;
-    protected _sharpness: number;
+    _brightness: number;
+    _sharpness: number;
 
     public brightness: number;
     public sharpness: number;
@@ -66,7 +66,7 @@ export namespace Lightbox {
  * @version 48
  */
 export class Lightbox extends St.Bin {
-    protected _active: boolean;
+    _active: boolean;
 
     public readonly active: boolean;
 
@@ -101,7 +101,7 @@ export class Lightbox extends St.Bin {
 
     highlight(window: Clutter.Actor): void;
 
-    protected _childAdded(container: Clutter.Actor, newChild: Clutter.Actor): void;
-    protected _childRemoved(container: Clutter.Actor, child: Clutter.Actor): void;
-    protected _onDestroy(): void;
+    _childAdded(container: Clutter.Actor, newChild: Clutter.Actor): void;
+    _childRemoved(container: Clutter.Actor, child: Clutter.Actor): void;
+    _onDestroy(): void;
 }

--- a/packages/gnome-shell/src/ui/lightbox.d.ts
+++ b/packages/gnome-shell/src/ui/lightbox.d.ts
@@ -31,11 +31,11 @@ export class RadialShaderEffect extends Shell.GLSLEffect {
     _brightness: number;
     _sharpness: number;
 
-    public brightness: number;
-    public sharpness: number;
+    brightness: number;
+    sharpness: number;
 
     constructor(props: Partial<RadialShaderEffect.ConstructorProps>);
-    public _init(props: Partial<RadialShaderEffect.ConstructorProps>): void;
+    _init(props: Partial<RadialShaderEffect.ConstructorProps>): void;
 
     vfunc_build_pipeline(): void;
 }
@@ -68,7 +68,7 @@ export namespace Lightbox {
 export class Lightbox extends St.Bin {
     _active: boolean;
 
-    public readonly active: boolean;
+    readonly active: boolean;
 
     /**
      * Lightbox creates a dark translucent "shade" actor to hide the
@@ -94,7 +94,7 @@ export class Lightbox extends St.Bin {
      * @param {boolean=} params.radialEffect: whether to enable the GLSL radial effect
      */
     constructor(container: Clutter.Actor, params?: Partial<Lightbox.ConstructorProps>);
-    public _init(container: Clutter.Actor, params?: Partial<Lightbox.ConstructorProps>): void;
+    _init(container: Clutter.Actor, params?: Partial<Lightbox.ConstructorProps>): void;
 
     lightOn(fadeInTime?: number): void;
     lightOff(fadeOutTime?: number): void;

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -16,14 +16,14 @@ export class URLHighlighter extends St.Label {
     constructor(text?: string, lineWrap?: boolean, allowMarkup?: boolean);
 
     /** @hidden */
-    public _init(params?: Partial<St.Label.ConstructorProps>): void;
-    public _init(text?: string, lineWrap?: boolean, allowMarkup?: boolean): void;
+    _init(params?: Partial<St.Label.ConstructorProps>): void;
+    _init(text?: string, lineWrap?: boolean, allowMarkup?: boolean): void;
 
-    public vfunc_button_press_event(buttonEvent: Clutter.ButtonEvent): boolean;
-    public vfunc_button_release_event(buttonEvent: Clutter.ButtonEvent): boolean;
-    public vfunc_motion_event(motionEvent: Clutter.MotionEvent): boolean;
-    public vfunc_leave_event(crossingEvent: Clutter.CrossingEvent): boolean;
-    public setMarkup(text?: string, allowMarkup?: boolean): void;
+    vfunc_button_press_event(buttonEvent: Clutter.ButtonEvent): boolean;
+    vfunc_button_release_event(buttonEvent: Clutter.ButtonEvent): boolean;
+    vfunc_motion_event(motionEvent: Clutter.MotionEvent): boolean;
+    vfunc_leave_event(crossingEvent: Clutter.CrossingEvent): boolean;
+    setMarkup(text?: string, allowMarkup?: boolean): void;
 
     _highlightUrls(): void;
     _findUrlAtPos(event: Clutter.Event): [number, number];
@@ -68,22 +68,22 @@ export declare namespace Source {
 export class Source extends GObject.Object implements Source.ObjectProperties {
     constructor(params?: Source.ConstructorProps);
 
-    public title: string;
-    public icon: Gio.Icon;
+    title: string;
+    icon: Gio.Icon;
 
-    public get iconName(): string | null;
+    get iconName(): string | null;
 
-    public set iconName(iconName: string);
+    set iconName(iconName: string);
 }
 
 declare class TimeLabel extends St.Label {
     datetime: Date;
 
     /** @hidden */
-    public _init(params?: Partial<St.Label.ConstructorProps>): void;
-    public _init(datetime: Date): void;
+    _init(params?: Partial<St.Label.ConstructorProps>): void;
+    _init(datetime: Date): void;
 
-    public vfunc_map(): void;
+    vfunc_map(): void;
 }
 
 declare class MessageHeader extends St.BoxLayout {
@@ -97,27 +97,27 @@ declare class MessageHeader extends St.BoxLayout {
 export class Message extends St.Button {
     constructor(source: Source);
 
-    public title: string | null;
-    public body: string | null;
-    public useBodyMarkup: boolean;
-    public icon: Gio.Icon | null;
-    public datetime: GLib.DateTime | null;
+    title: string | null;
+    body: string | null;
+    useBodyMarkup: boolean;
+    icon: Gio.Icon | null;
+    datetime: GLib.DateTime | null;
 
-    public expanded: boolean;
+    expanded: boolean;
 
-    public close(): void;
+    close(): void;
 
-    public setActionArea(actor: Clutter.Actor): void;
+    setActionArea(actor: Clutter.Actor): void;
 
-    public addMediaControl(iconName: string, callback: () => void): void;
+    addMediaControl(iconName: string, callback: () => void): void;
 
-    public expand(animate?: boolean): void;
+    expand(animate?: boolean): void;
 
-    public unexpand(animate?: boolean): void;
+    unexpand(animate?: boolean): void;
 
-    public canClose(): boolean;
+    canClose(): boolean;
 
-    public vfunc_key_press_event(keyEvent: Clutter.KeyEvent): boolean;
+    vfunc_key_press_event(keyEvent: Clutter.KeyEvent): boolean;
 }
 
 /**
@@ -129,10 +129,10 @@ export class NotificationMessage extends Message {
     override _init(params?: Partial<St.Button.ConstructorProps>): void;
     /** @hidden */
     override _init(title: string, body: string): void;
-    public _init(notification: Notification): void;
+    _init(notification: Notification): void;
 
-    public vfunc_clicked(): void;
-    public canClose(): boolean;
+    vfunc_clicked(): void;
+    canClose(): boolean;
 
     _getIcon(): St.Icon;
     _onUpdated(n: Notification, _clear?: boolean): void;
@@ -150,12 +150,12 @@ declare class MediaMessage extends Message {
     constructor(player: MprisPlayer);
 
     /** @hidden */
-    public override _init(params?: Partial<St.Button.ConstructorProps>): void;
+    override _init(params?: Partial<St.Button.ConstructorProps>): void;
     /** @hidden */
-    public override _init(title: string, body: string): void;
-    public _init(player: MprisPlayer): void;
+    override _init(title: string, body: string): void;
+    _init(player: MprisPlayer): void;
 
-    public vfunc_clicked(): void;
+    vfunc_clicked(): void;
 
     _updateNavButton(button: St.Button, sensitive?: boolean): void;
     _update(): void;

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -25,8 +25,8 @@ export class URLHighlighter extends St.Label {
     public vfunc_leave_event(crossingEvent: Clutter.CrossingEvent): boolean;
     public setMarkup(text?: string, allowMarkup?: boolean): void;
 
-    protected _highlightUrls(): void;
-    protected _findUrlAtPos(event: Clutter.Event): [number, number];
+    _highlightUrls(): void;
+    _findUrlAtPos(event: Clutter.Event): [number, number];
 }
 
 declare class ScaleLayout extends Clutter.BinLayout {
@@ -134,18 +134,18 @@ export class NotificationMessage extends Message {
     public vfunc_clicked(): void;
     public canClose(): boolean;
 
-    protected _getIcon(): St.Icon;
-    protected _onUpdated(n: Notification, _clear?: boolean): void;
+    _getIcon(): St.Icon;
+    _onUpdated(n: Notification, _clear?: boolean): void;
 }
 
 declare class MediaMessage extends Message {
-    protected _player: MprisPlayer;
-    protected _icon: St.Icon;
-    protected _secondaryBin: St.Bin;
-    protected _closeButton: St.Button;
-    protected _prevButton: St.Button;
-    protected _playPauseButton: St.Button;
-    protected _nextButton: St.Button;
+    _player: MprisPlayer;
+    _icon: St.Icon;
+    _secondaryBin: St.Bin;
+    _closeButton: St.Button;
+    _prevButton: St.Button;
+    _playPauseButton: St.Button;
+    _nextButton: St.Button;
 
     constructor(player: MprisPlayer);
 
@@ -157,8 +157,8 @@ declare class MediaMessage extends Message {
 
     public vfunc_clicked(): void;
 
-    protected _updateNavButton(button: St.Button, sensitive?: boolean): void;
-    protected _update(): void;
+    _updateNavButton(button: St.Button, sensitive?: boolean): void;
+    _update(): void;
 }
 
 declare class NotificationMessageGroup extends St.Widget {

--- a/packages/gnome-shell/src/ui/messageTray.d.ts
+++ b/packages/gnome-shell/src/ui/messageTray.d.ts
@@ -96,7 +96,7 @@ export abstract class NotificationPolicy extends GObject.Object {
     readonly showInLockScreen: boolean;
     readonly detailsInLockScreen: boolean;
 
-    public static newForApp(app: Shell.App): NotificationPolicy;
+    static newForApp(app: Shell.App): NotificationPolicy;
 
     /**
      * Do nothing for the default policy. These methods are only useful for the
@@ -112,14 +112,14 @@ export abstract class NotificationPolicy extends GObject.Object {
  * @version 48
  */
 export class NotificationGenericPolicy extends NotificationPolicy {
-    public id: string;
+    id: string;
 
     _masterSettings: Gio.Settings;
 
     constructor();
-    public _init(): void;
+    _init(): void;
 
-    public destroy(): void;
+    destroy(): void;
 
     _changed(settings: Gio.Settings, key: string): void;
 }
@@ -129,17 +129,17 @@ export class NotificationGenericPolicy extends NotificationPolicy {
  * @version 48
  */
 export class NotificationApplicationPolicy extends NotificationPolicy {
-    public id: string;
+    id: string;
 
     _masterSettings: Gio.Settings;
     _canonicalId: string;
     _settings: Gio.Settings;
 
     constructor(id: string);
-    public _init(id: string): void;
+    _init(id: string): void;
 
-    public store(): void;
-    public destroy(): void;
+    store(): void;
+    destroy(): void;
 
     _changed(settings: Gio.Settings, key: string): void;
     _canonicalizeId(id: string): string;
@@ -152,7 +152,7 @@ export class NotificationApplicationPolicy extends NotificationPolicy {
 export class Sound extends GObject.Object {
     constructor(file: Gio.File | null | undefined, themedName?: string);
 
-    public play(): void;
+    play(): void;
 }
 
 /**
@@ -162,9 +162,9 @@ export class Sound extends GObject.Object {
 export class Action extends GObject.Object {
     constructor(label: string, callback: () => void);
 
-    public readonly label: string;
+    readonly label: string;
 
-    public activate(): void;
+    activate(): void;
 }
 
 /**
@@ -184,27 +184,27 @@ export declare namespace Source {
 export class Source extends MessageList.Source {
     constructor(params?: Partial<Source.ConstructorProps>);
 
-    public readonly notifications: readonly Notification[];
+    readonly notifications: readonly Notification[];
 
-    public policy: NotificationPolicy;
+    policy: NotificationPolicy;
 
-    public readonly count: number;
+    readonly count: number;
 
-    public readonly unseenCount: number;
+    readonly unseenCount: number;
 
-    public readonly countVisible: number;
+    readonly countVisible: number;
 
-    public countUpdated(): void;
+    countUpdated(): void;
 
-    public readonly narrowestPrivacyScope: PrivacyScope;
+    readonly narrowestPrivacyScope: PrivacyScope;
 
-    public addNotification(notification: Notification): void;
+    addNotification(notification: Notification): void;
 
-    public destroy(reason: NotificationDestroyedReason): void;
+    destroy(reason: NotificationDestroyedReason): void;
 
-    public open(): void;
+    open(): void;
 
-    public destroyNonResidentNotifications(): void;
+    destroyNonResidentNotifications(): void;
 
     // General signal handler methods
     connect(sigName: string, callback: (...args: any[]) => void): number;
@@ -323,18 +323,18 @@ export class Notification extends GObject.Object implements Notification.ObjectP
 export class MessageTray extends St.Widget {
     constructor();
 
-    public idleMonitor: GnomeDesktop.IdleMonitor;
+    idleMonitor: GnomeDesktop.IdleMonitor;
 
-    public bannerAlignment: number;
+    bannerAlignment: number;
 
-    public readonly queueCount: number;
+    readonly queueCount: number;
 
-    public set bannerBlocked(v: boolean);
+    set bannerBlocked(v: boolean);
 
-    public contains(descendant: Clutter.Actor): boolean;
-    public contains(source: Source): boolean;
-    public add(source: Source): void;
-    public getSources(): Source[];
+    contains(descendant: Clutter.Actor): boolean;
+    contains(source: Source): boolean;
+    add(source: Source): void;
+    getSources(): Source[];
 
     _sessionUpdated(): void;
     _onDragBegin(): void;

--- a/packages/gnome-shell/src/ui/messageTray.d.ts
+++ b/packages/gnome-shell/src/ui/messageTray.d.ts
@@ -114,14 +114,14 @@ export abstract class NotificationPolicy extends GObject.Object {
 export class NotificationGenericPolicy extends NotificationPolicy {
     public id: string;
 
-    protected _masterSettings: Gio.Settings;
+    _masterSettings: Gio.Settings;
 
     constructor();
     public _init(): void;
 
     public destroy(): void;
 
-    protected _changed(settings: Gio.Settings, key: string): void;
+    _changed(settings: Gio.Settings, key: string): void;
 }
 
 /**
@@ -131,9 +131,9 @@ export class NotificationGenericPolicy extends NotificationPolicy {
 export class NotificationApplicationPolicy extends NotificationPolicy {
     public id: string;
 
-    protected _masterSettings: Gio.Settings;
-    protected _canonicalId: string;
-    protected _settings: Gio.Settings;
+    _masterSettings: Gio.Settings;
+    _canonicalId: string;
+    _settings: Gio.Settings;
 
     constructor(id: string);
     public _init(id: string): void;
@@ -141,8 +141,8 @@ export class NotificationApplicationPolicy extends NotificationPolicy {
     public store(): void;
     public destroy(): void;
 
-    protected _changed(settings: Gio.Settings, key: string): void;
-    protected _canonicalizeId(id: string): string;
+    _changed(settings: Gio.Settings, key: string): void;
+    _canonicalizeId(id: string): string;
 }
 
 /**
@@ -336,21 +336,21 @@ export class MessageTray extends St.Widget {
     public add(source: Source): void;
     public getSources(): Source[];
 
-    protected _sessionUpdated(): void;
-    protected _onDragBegin(): void;
-    protected _onDragEnd(): void;
+    _sessionUpdated(): void;
+    _onDragBegin(): void;
+    _onDragEnd(): void;
 
-    protected _onNotificationKeyRelease(actor: St.Widget, event: Clutter.Event): boolean;
-    protected _expireNotification(): void;
-    protected _addSource(source: Source): void;
-    protected _removeSource(source: Source): void;
-    protected _onSourceEnableChanged(policy: NotificationPolicy, source: Source): void;
-    protected _onNotificationRemoved(source: Source, notification: Notification): void;
-    protected _onNotificationShow(_source: Source, notification: Notification): void;
-    protected _resetNotificationLeftTimeout(): void;
-    protected _onNotificationHoverChanged(): void;
-    protected _onStatusChanged(status: PresenceStatus): void;
-    protected _onNotificationLeftTimeout(): void;
+    _onNotificationKeyRelease(actor: St.Widget, event: Clutter.Event): boolean;
+    _expireNotification(): void;
+    _addSource(source: Source): void;
+    _removeSource(source: Source): void;
+    _onSourceEnableChanged(policy: NotificationPolicy, source: Source): void;
+    _onNotificationRemoved(source: Source, notification: Notification): void;
+    _onNotificationShow(_source: Source, notification: Notification): void;
+    _resetNotificationLeftTimeout(): void;
+    _onNotificationHoverChanged(): void;
+    _onStatusChanged(status: PresenceStatus): void;
+    _onNotificationLeftTimeout(): void;
 
     /**
      * All of the logic for what happens when occurs here; the various
@@ -359,19 +359,19 @@ export class MessageTray extends St.Widget {
      * _updateState() figures out what (if anything) needs to be done
      * at the present time.
      */
-    protected _updateState(): void;
+    _updateState(): void;
 
-    protected _onIdleMonitorBecameActive(): void;
-    protected _showNotification(): void;
-    protected _updateShowingNotification(): void;
-    protected _showNotificationCompleted(): void;
-    protected _updateNotificationTimeout(timeout: number): void;
-    protected _notificationTimeout(): void;
-    protected _hideNotification(animate?: boolean): void;
-    protected _hideNotificationCompleted(): void;
-    protected _expandActiveNotification(): void;
-    protected _expandBanner(autoExpanding?: boolean): void;
-    protected _ensureBannerFocused(): void;
+    _onIdleMonitorBecameActive(): void;
+    _showNotification(): void;
+    _updateShowingNotification(): void;
+    _showNotificationCompleted(): void;
+    _updateNotificationTimeout(timeout: number): void;
+    _notificationTimeout(): void;
+    _hideNotification(animate?: boolean): void;
+    _hideNotificationCompleted(): void;
+    _expandActiveNotification(): void;
+    _expandBanner(autoExpanding?: boolean): void;
+    _ensureBannerFocused(): void;
 
     // General signal handler methods
     connect(sigName: string, callback: (...args: any[]) => void): number;

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -38,18 +38,18 @@ export namespace ModalDialog {
  * @version 47
  */
 export class ModalDialog extends St.Widget {
-    protected _state: State;
-    protected _hasModal: boolean;
-    protected _actionMode: Shell.ActionMode;
-    protected _shellReactive: boolean;
-    protected _shouldFadeIn: boolean;
-    protected _shouldFadeOut: boolean;
-    protected _destroyOnClose: boolean;
-    protected _backgroundBin: St.Bin;
-    protected _monitorConstraint: MonitorConstraint;
-    protected _initialKeyFocus: St.Widget | null;
-    protected _initialKeyFocusDestroyId: number;
-    protected _savedKeyFocus: St.Widget | null;
+    _state: State;
+    _hasModal: boolean;
+    _actionMode: Shell.ActionMode;
+    _shellReactive: boolean;
+    _shouldFadeIn: boolean;
+    _shouldFadeOut: boolean;
+    _destroyOnClose: boolean;
+    _backgroundBin: St.Bin;
+    _monitorConstraint: MonitorConstraint;
+    _initialKeyFocus: St.Widget | null;
+    _initialKeyFocusDestroyId: number;
+    _savedKeyFocus: St.Widget | null;
 
     public backgroundStack: St.Widget;
     public dialogLayout: Dialog;
@@ -61,9 +61,9 @@ export class ModalDialog extends St.Widget {
 
     public _init(params?: Partial<ModalDialog.ConstructorProps>): void;
 
-    protected _setState(state: State): void;
-    protected _fadeOpen(onPrimary: boolean): void;
-    protected _closeComplete(): void;
+    _setState(state: State): void;
+    _fadeOpen(onPrimary: boolean): void;
+    _closeComplete(): void;
     /**
      * This method is like close, but fades the dialog out much slower,
      * and leaves the lightbox in place. Once in the faded out state,
@@ -77,7 +77,7 @@ export class ModalDialog extends St.Widget {
      * immediately, but the lightbox should remain until the logout is
      * complete.
      */
-    protected _fadeOutDialog(timestamp: number): void;
+    _fadeOutDialog(timestamp: number): void;
 
     public vfunc_key_press_event(event: Clutter.Event): boolean;
     public vfunc_captured_event(event: Clutter.Event): boolean;

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -51,15 +51,15 @@ export class ModalDialog extends St.Widget {
     _initialKeyFocusDestroyId: number;
     _savedKeyFocus: St.Widget | null;
 
-    public backgroundStack: St.Widget;
-    public dialogLayout: Dialog;
-    public contentLayout: Dialog['contentLayout'];
-    public buttonLayout: Dialog['buttonLayout'];
-    public readonly state: State;
+    backgroundStack: St.Widget;
+    dialogLayout: Dialog;
+    contentLayout: Dialog['contentLayout'];
+    buttonLayout: Dialog['buttonLayout'];
+    readonly state: State;
 
     constructor(params?: Partial<ModalDialog.ConstructorProps>);
 
-    public _init(params?: Partial<ModalDialog.ConstructorProps>): void;
+    _init(params?: Partial<ModalDialog.ConstructorProps>): void;
 
     _setState(state: State): void;
     _fadeOpen(onPrimary: boolean): void;
@@ -79,20 +79,20 @@ export class ModalDialog extends St.Widget {
      */
     _fadeOutDialog(timestamp: number): void;
 
-    public vfunc_key_press_event(event: Clutter.Event): boolean;
-    public vfunc_captured_event(event: Clutter.Event): boolean;
+    vfunc_key_press_event(event: Clutter.Event): boolean;
+    vfunc_captured_event(event: Clutter.Event): boolean;
 
-    public clearButtons(): void;
-    public setButtons(buttons: ButtonInfo[]): void;
-    public addButton(buttonInfo: ButtonInfo): St.Button;
-    public setInitialKeyFocus(actor: St.Widget): void;
-    public open(): boolean;
-    public close(): boolean;
+    clearButtons(): void;
+    setButtons(buttons: ButtonInfo[]): void;
+    addButton(buttonInfo: ButtonInfo): St.Button;
+    setInitialKeyFocus(actor: St.Widget): void;
+    open(): boolean;
+    close(): boolean;
     /**
      * Drop modal status without closing the dialog; this makes the
      * dialog insensitive as well, so it needs to be followed shortly
      * by either a close() or a pushModal()
      */
-    public popModal(): void;
-    public pushModal(): void;
+    popModal(): void;
+    pushModal(): void;
 }

--- a/packages/gnome-shell/src/ui/mpris.d.ts
+++ b/packages/gnome-shell/src/ui/mpris.d.ts
@@ -31,11 +31,11 @@ export class MprisSource extends NotificationMessageGroup {
     _players: Map<string, MprisPlayer>;
     _proxy: Gio.DBusProxy;
 
-    public readonly allowed: boolean;
+    readonly allowed: boolean;
 
     /** @hidden */
-    public _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
-    public _init(): void;
+    _init(params?: Partial<St.BoxLayout.ConstructorProps>): void;
+    _init(): void;
 
     _addPlayer(busName: string): void;
     _onProxyReady(): Promise<void>;

--- a/packages/gnome-shell/src/ui/panelMenu.d.ts
+++ b/packages/gnome-shell/src/ui/panelMenu.d.ts
@@ -23,10 +23,10 @@ declare class ButtonBox extends St.Widget {
     _init(params: Partial<ButtonBox.ConstructorProps>): void;
     container: St.Bin;
 
-    public vfunc_get_preferred_width(_forHeight: number): [number, number];
-    public vfunc_get_preferred_height(_forWidth: number): [number, number];
+    vfunc_get_preferred_width(_forHeight: number): [number, number];
+    vfunc_get_preferred_height(_forWidth: number): [number, number];
 
-    public vfunc_allocate(box: Clutter.ActorBox): void;
+    vfunc_allocate(box: Clutter.ActorBox): void;
 }
 
 /**
@@ -53,9 +53,9 @@ export class Button extends ButtonBox {
     setSensitive(sensitive: boolean): void;
     setMenu(menu: PopupMenu | PopupDummyMenu): void;
 
-    public vfunc_event(event: Clutter.Event): boolean;
+    vfunc_event(event: Clutter.Event): boolean;
 
-    public vfunc_hide(): void;
+    vfunc_hide(): void;
 
     // General signal handler methods
     connect(sigName: string, callback: (...args: any[]) => void): number;

--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -218,7 +218,7 @@ export namespace PopupMenuBase {
  * @version 48
  */
 export class PopupMenuBase<S extends Signals.SignalMap<S> = PopupMenuBase.SignalMap> extends Signals.EventEmitter<S> {
-    protected constructor(sourceActor: St.Widget, styleClass?: string);
+    constructor(sourceActor: St.Widget, styleClass?: string);
     readonly sourceActor: St.Widget;
     readonly focusActor: St.Widget;
     readonly length: number;

--- a/packages/gnome-shell/src/ui/quickSettings.d.ts
+++ b/packages/gnome-shell/src/ui/quickSettings.d.ts
@@ -61,10 +61,10 @@ export class QuickToggle extends QuickSettingsItem {
     subtitle: string | null;
     gicon: Gio.Icon;
 
-    private _box: St.BoxLayout;
-    private _icon: St.Icon;
-    private _title: St.Label;
-    private _subtitle: St.Label;
+    _box: St.BoxLayout;
+    _icon: St.Icon;
+    _title: St.Label;
+    _subtitle: St.Label;
 
     /**
      * Initializes a new instance of `QuickToggle`.
@@ -105,8 +105,8 @@ export class QuickMenuToggle extends QuickSettingsItem {
     gicon: Gio.Icon;
     menuEnabled: boolean;
 
-    private _box: St.BoxLayout;
-    private _menuButton: St.Button;
+    _box: St.BoxLayout;
+    _menuButton: St.Button;
 
     /**
      * Initializes a new instance of `QuickMenuToggle`.
@@ -145,9 +145,9 @@ export class QuickSlider extends QuickSettingsItem {
     menuEnabled: boolean;
     slider: Slider;
 
-    private _icon: St.Icon;
-    private _iconButton: St.Button;
-    private _menuButton: St.Button;
+    _icon: St.Icon;
+    _iconButton: St.Button;
+    _menuButton: St.Button;
 
     /**
      * Initializes a new instance of `QuickSlider`.
@@ -169,11 +169,11 @@ export class QuickSlider extends QuickSettingsItem {
 export class QuickToggleMenu extends PopupMenu.PopupMenuBase {
     actor: St.Widget;
 
-    private _header: St.Widget;
-    private _headerIcon: St.Icon;
-    private _headerTitle: St.Label;
-    private _headerSubtitle: St.Label;
-    private _headerSpacer: Clutter.Actor;
+    _header: St.Widget;
+    _headerIcon: St.Icon;
+    _headerTitle: St.Label;
+    _headerSubtitle: St.Label;
+    _headerSpacer: Clutter.Actor;
 
     /**
      * Initializes a new instance of `QuickToggleMenu`.
@@ -193,9 +193,9 @@ export class QuickToggleMenu extends PopupMenu.PopupMenuBase {
     open(animate: boolean): void;
     close(animate: boolean): void;
 
-    private _syncChecked(): void;
+    _syncChecked(): void;
 
-    private _setOpenedSubMenu(submenu: PopupMenu.PopupSubMenu | null): void;
+    _setOpenedSubMenu(submenu: PopupMenu.PopupSubMenu | null): void;
 }
 
 /**
@@ -236,7 +236,7 @@ export class QuickSettingsLayout extends Clutter.LayoutManager {
     /**
      * Overlay actor passed to the constructor
      */
-    private _overlay: Clutter.Actor;
+    _overlay: Clutter.Actor;
 
     /**
      * Initializes a new instance of QuickSettingsLayout.
@@ -273,11 +273,11 @@ export class QuickSettingsLayout extends Clutter.LayoutManager {
      */
     vfunc_allocate(container: Clutter.Actor, box: Clutter.ActorBox): void;
 
-    private _containerStyleChanged(): void;
-    private _getColSpan(container: Clutter.Actor, child: Clutter.Actor): number;
-    private _getMaxChildWidth(container: Clutter.Actor): [number, number];
-    private _getRows(container: Clutter.Actor): Clutter.Actor[][];
-    private _getRowHeight(children: Clutter.Actor[]): [number, number];
+    _containerStyleChanged(): void;
+    _getColSpan(container: Clutter.Actor, child: Clutter.Actor): number;
+    _getMaxChildWidth(container: Clutter.Actor): [number, number];
+    _getRows(container: Clutter.Actor): Clutter.Actor[][];
+    _getRowHeight(children: Clutter.Actor[]): [number, number];
 }
 
 /**
@@ -287,10 +287,10 @@ export class QuickSettingsLayout extends Clutter.LayoutManager {
  * @version 46
  */
 export class QuickSettingsMenu extends PopupMenu.PopupMenu {
-    private _dimEffect: Clutter.BrightnessContrastEffect;
-    private _boxPointer: St.Widget;
-    private _grid: St.Widget;
-    private _overlay: Clutter.Actor;
+    _dimEffect: Clutter.BrightnessContrastEffect;
+    _boxPointer: St.Widget;
+    _grid: St.Widget;
+    _overlay: Clutter.Actor;
 
     /**
      * Initializes a new instance of QuickSettingsMenu.
@@ -315,8 +315,8 @@ export class QuickSettingsMenu extends PopupMenu.PopupMenu {
     open(animate: boolean): void;
     close(animate: boolean): void;
 
-    private _completeAddItem(item: Clutter.Actor, colSpan: number): void;
-    private _setDimmed(dim: boolean): void;
+    _completeAddItem(item: Clutter.Actor, colSpan: number): void;
+    _setDimmed(dim: boolean): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/ripples.d.ts
+++ b/packages/gnome-shell/src/ui/ripples.d.ts
@@ -14,9 +14,9 @@ export class Ripples {
 
     constructor(px: number, py: number, styleClass: string | null);
 
-    public destroy(): void;
-    public addTo(stage: Clutter.Stage): void;
-    public playAnimation(x: number, y: number): void;
+    destroy(): void;
+    addTo(stage: Clutter.Stage): void;
+    playAnimation(x: number, y: number): void;
 
     /**
      * We draw a ripple by using a source image and animating it scaling

--- a/packages/gnome-shell/src/ui/ripples.d.ts
+++ b/packages/gnome-shell/src/ui/ripples.d.ts
@@ -32,5 +32,5 @@ export class Ripples {
      * @param startOpacity
      * @param finalScale
      */
-    protected _animRipple(ripple: St.BoxLayout, delay: number, duration: number, startScale: number, startOpacity: number, finalScale: number): void;
+    _animRipple(ripple: St.BoxLayout, delay: number, duration: number, startScale: number, startOpacity: number, finalScale: number): void;
 }

--- a/packages/gnome-shell/src/ui/search.d.ts
+++ b/packages/gnome-shell/src/ui/search.d.ts
@@ -9,57 +9,57 @@ export class MaxWidthBox extends St.BoxLayout {}
 
 export class SearchResult extends St.Button {
     /** @hidden */
-    public _init(config?: Partial<St.Button.ConstructorProps>): void;
-    public _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
+    _init(config?: Partial<St.Button.ConstructorProps>): void;
+    _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
 
     activate(): void;
 }
 
 export class ListSearchResult extends SearchResult {
     /** @hidden */
-    public _init(config?: Partial<St.Button.ConstructorProps>): void;
-    public _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
+    _init(config?: Partial<St.Button.ConstructorProps>): void;
+    _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
 }
 
 export class GridSearchResult extends SearchResult {
-    public readonly focusChild: St.Widget;
+    readonly focusChild: St.Widget;
 
     /** @hidden */
-    public _init(config?: Partial<St.Button.ConstructorProps>): void;
-    public _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
+    _init(config?: Partial<St.Button.ConstructorProps>): void;
+    _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
 
     _onDestroy(): void;
     _createResultDisplay(meta: any): void;
     _keyFocusIn(actor: St.Widget): void;
     _ensureResultActors(results: any[]): Promise<void>;
 
-    public clear(): void;
-    public updateSearch(providerResults: any[], terms: string[], callback: () => void): Promise<void>;
+    clear(): void;
+    updateSearch(providerResults: any[], terms: string[], callback: () => void): Promise<void>;
 }
 
 export abstract class SearchResultsBase extends St.BoxLayout {
     /** @hidden */
-    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
+    _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     /** @hidden */
-    public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
-    public _init(props?: { style_class?: string; vertical?: boolean }): void;
+    _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
+    _init(props?: { style_class?: string; vertical?: boolean }): void;
 
-    public activateDefault(): void;
-    public highlightDefault(highlight: boolean): void;
-    public popupMenuDefault(): void;
-    public navigateFocus(direction: St.DirectionType): boolean;
-    public highlightTerms(description: string): string;
+    activateDefault(): void;
+    highlightDefault(highlight: boolean): void;
+    popupMenuDefault(): void;
+    navigateFocus(direction: St.DirectionType): boolean;
+    highlightTerms(description: string): string;
 }
 
 export class ListSearchResults extends SearchResultsBase {
     /** @hidden */
-    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
+    _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     /** @hidden */
-    public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
+    _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
     /** @hidden */
-    public _init(props?: { style_class?: string; vertical?: boolean }): void;
+    _init(props?: { style_class?: string; vertical?: boolean }): void;
 
-    public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
+    _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
 
     _setMoreCount(count: number): void;
     _getMaxDisplayedResults(): number;
@@ -67,26 +67,26 @@ export class ListSearchResults extends SearchResultsBase {
     _createResultDisplay(meta: any): void;
     _addItem(display: any): void;
 
-    public getFirstResult(): any | null;
+    getFirstResult(): any | null;
 }
 
 export class GridSearchResultsLayout extends Clutter.LayoutManager {
-    public spacing: number;
+    spacing: number;
 
     /** @hidden */
-    public _init(config?: Partial<Clutter.LayoutManager.ConstructorProps>): void;
-    public _init(): void;
+    _init(config?: Partial<Clutter.LayoutManager.ConstructorProps>): void;
+    _init(): void;
 
-    public columnsForWidth(width: number): number;
+    columnsForWidth(width: number): number;
 }
 
 export class GridSearchResults extends SearchResultsBase {
     /** @hidden */
-    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
+    _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     /** @hidden */
-    public _init(props?: { style_class?: string; vertical?: boolean }): void;
+    _init(props?: { style_class?: string; vertical?: boolean }): void;
 
-    public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
+    _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
 
     _onDestroy(): void;
     _getMaxDisplayedResults(): number;
@@ -94,17 +94,17 @@ export class GridSearchResults extends SearchResultsBase {
     _createResultDisplay(meta: any): void;
     _addItem(display: any): void;
 
-    public updateSearch(...args: any[]): void;
-    public getFirstResult(): any | null;
+    updateSearch(...args: any[]): void;
+    getFirstResult(): any | null;
 }
 
 export class SearchResultsView extends St.BoxLayout {
-    public readonly terms: string[];
-    public readonly searchInProgress: boolean;
+    readonly terms: string[];
+    readonly searchInProgress: boolean;
 
     /** @hidden */
-    public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
-    public _init(): void;
+    _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
+    _init(): void;
 
     _reloadRemoteProviders(): void;
     _registerProvider(provider: AppSearchProvider): void;
@@ -123,22 +123,22 @@ export class SearchResultsView extends St.BoxLayout {
     _updateResults(provider: AppSearchProvider, results: any[]): void;
     _setSelected(result: any, selected: boolean): void;
 
-    public setTerms(terms: string[]): void;
-    public activateDefault(): void;
-    public highlightDefault(highlight: boolean): void;
-    public popupMenuDefault(): void;
-    public navigateFocus(direction: St.DirectionType): boolean;
-    public highlightTerms(description: string): string;
+    setTerms(terms: string[]): void;
+    activateDefault(): void;
+    highlightDefault(highlight: boolean): void;
+    popupMenuDefault(): void;
+    navigateFocus(direction: St.DirectionType): boolean;
+    highlightTerms(description: string): string;
 }
 
 export class ProviderInfo extends St.Button {
     readonly PROVIDER_ICON_SIZE: number;
 
     /** @hidden */
-    public _init(config?: Partial<St.Button.ConstructorProps>): void;
+    _init(config?: Partial<St.Button.ConstructorProps>): void;
 
-    public _init(provider: AppSearchProvider): void;
+    _init(provider: AppSearchProvider): void;
 
-    public animateLaunch(): void;
-    public setMoreCount(count: number): void;
+    animateLaunch(): void;
+    setMoreCount(count: number): void;
 }

--- a/packages/gnome-shell/src/ui/search.d.ts
+++ b/packages/gnome-shell/src/ui/search.d.ts
@@ -28,10 +28,10 @@ export class GridSearchResult extends SearchResult {
     public _init(config?: Partial<St.Button.ConstructorProps>): void;
     public _init(provider: AppSearchProvider, metaInfo: any, resultsView: SearchResultsView): void;
 
-    protected _onDestroy(): void;
-    protected _createResultDisplay(meta: any): void;
-    protected _keyFocusIn(actor: St.Widget): void;
-    protected _ensureResultActors(results: any[]): Promise<void>;
+    _onDestroy(): void;
+    _createResultDisplay(meta: any): void;
+    _keyFocusIn(actor: St.Widget): void;
+    _ensureResultActors(results: any[]): Promise<void>;
 
     public clear(): void;
     public updateSearch(providerResults: any[], terms: string[], callback: () => void): Promise<void>;
@@ -61,11 +61,11 @@ export class ListSearchResults extends SearchResultsBase {
 
     public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
 
-    protected _setMoreCount(count: number): void;
-    protected _getMaxDisplayedResults(): number;
-    protected _clearResultDisplay(): void;
-    protected _createResultDisplay(meta: any): void;
-    protected _addItem(display: any): void;
+    _setMoreCount(count: number): void;
+    _getMaxDisplayedResults(): number;
+    _clearResultDisplay(): void;
+    _createResultDisplay(meta: any): void;
+    _addItem(display: any): void;
 
     public getFirstResult(): any | null;
 }
@@ -88,11 +88,11 @@ export class GridSearchResults extends SearchResultsBase {
 
     public _init(provider: AppSearchProvider, resultsView: SearchResultsView): void;
 
-    protected _onDestroy(): void;
-    protected _getMaxDisplayedResults(): number;
-    protected _clearResultDisplay(): void;
-    protected _createResultDisplay(meta: any): void;
-    protected _addItem(display: any): void;
+    _onDestroy(): void;
+    _getMaxDisplayedResults(): number;
+    _clearResultDisplay(): void;
+    _createResultDisplay(meta: any): void;
+    _addItem(display: any): void;
 
     public updateSearch(...args: any[]): void;
     public getFirstResult(): any | null;
@@ -106,22 +106,22 @@ export class SearchResultsView extends St.BoxLayout {
     public _init(config?: Partial<St.BoxLayout.ConstructorProps>): void;
     public _init(): void;
 
-    protected _reloadRemoteProviders(): void;
-    protected _registerProvider(provider: AppSearchProvider): void;
-    protected _unregisterProvider(provider: AppSearchProvider): void;
-    protected _clearSearchTimeout(): void;
-    protected _reset(): void;
-    protected _doProviderSearch(provider: AppSearchProvider, previousResults: any[]): Promise<any[]>;
-    protected _doSearch(): void;
-    protected _onSearchTimeout(): void;
-    protected _onPan(action: any): void;
-    protected _focusChildChanged(provider: AppSearchProvider): void;
-    protected _ensureProviderDisplay(provider: AppSearchProvider): void;
-    protected _clearDisplay(): void;
-    protected _maybeSetInitialSelection(): void;
-    protected _updateSearchProgress(): void;
-    protected _updateResults(provider: AppSearchProvider, results: any[]): void;
-    protected _setSelected(result: any, selected: boolean): void;
+    _reloadRemoteProviders(): void;
+    _registerProvider(provider: AppSearchProvider): void;
+    _unregisterProvider(provider: AppSearchProvider): void;
+    _clearSearchTimeout(): void;
+    _reset(): void;
+    _doProviderSearch(provider: AppSearchProvider, previousResults: any[]): Promise<any[]>;
+    _doSearch(): void;
+    _onSearchTimeout(): void;
+    _onPan(action: any): void;
+    _focusChildChanged(provider: AppSearchProvider): void;
+    _ensureProviderDisplay(provider: AppSearchProvider): void;
+    _clearDisplay(): void;
+    _maybeSetInitialSelection(): void;
+    _updateSearchProgress(): void;
+    _updateResults(provider: AppSearchProvider, results: any[]): void;
+    _setSelected(result: any, selected: boolean): void;
 
     public setTerms(terms: string[]): void;
     public activateDefault(): void;

--- a/packages/gnome-shell/src/ui/slider.d.ts
+++ b/packages/gnome-shell/src/ui/slider.d.ts
@@ -37,7 +37,7 @@ export class Slider extends BarLevel.BarLevel {
      * Ends dragging the slider.
      * @returns The event propagation status.
      */
-    protected _endDragging(): typeof Clutter.EVENT_PROPAGATE;
+    _endDragging(): typeof Clutter.EVENT_PROPAGATE;
 
     /**
      * Handles button release events.
@@ -72,7 +72,7 @@ export class Slider extends BarLevel.BarLevel {
      * @param event The Clutter motion event.
      * @returns The event propagation status.
      */
-    protected _motionEvent(actor: Clutter.Actor, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
+    _motionEvent(actor: Clutter.Actor, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
 
     /**
      * Handles key press events for the slider.
@@ -86,11 +86,11 @@ export class Slider extends BarLevel.BarLevel {
      * @param absX The absolute X coordinate.
      * @param _absY The absolute Y coordinate.
      */
-    protected _moveHandle(absX: number, _absY: number): void;
+    _moveHandle(absX: number, _absY: number): void;
 
     /**
      * Retrieves the minimum increment value for accessibility adjustments.
      * @returns The minimum increment value.
      */
-    protected _getMinimumIncrement(): number;
+    _getMinimumIncrement(): number;
 }

--- a/packages/gnome-shell/src/ui/status/autoRotate.d.ts
+++ b/packages/gnome-shell/src/ui/status/autoRotate.d.ts
@@ -9,8 +9,8 @@ import { QuickToggle, SystemIndicator } from '../quickSettings.js';
  * This class extends `QuickToggle`.
  */
 export declare class RotationToggle extends QuickToggle {
-    private _systemActions: SystemActions.SystemActions;
-    private _settings: Gio.Settings;
+    _systemActions: SystemActions.SystemActions;
+    _settings: Gio.Settings;
 
     /**
      * Initializes a new instance of `RotationToggle`.

--- a/packages/gnome-shell/src/ui/status/backgroundApps.d.ts
+++ b/packages/gnome-shell/src/ui/status/backgroundApps.d.ts
@@ -14,8 +14,8 @@ declare const BackgroundMonitorProxy: typeof Gio.DBusProxy;
  * This class extends `PopupMenu.PopupImageMenuItem`.
  */
 export declare class BackgroundAppMenuItem extends PopupMenu.PopupImageMenuItem {
-    private _spinner: Spinner;
-    private _spinnerTimeoutId: number | null;
+    _spinner: Spinner;
+    _spinnerTimeoutId: number | null;
     app: Shell.App;
     message: string;
 
@@ -47,10 +47,10 @@ export declare class BackgroundAppMenuItem extends PopupMenu.PopupImageMenuItem 
  * This class extends `QuickToggle`.
  */
 export declare class BackgroundAppsToggle extends QuickToggle {
-    private _appSystem: typeof Shell.AppSystem;
-    private _proxy: typeof BackgroundMonitorProxy | null;
-    private _listTitle: PopupMenu.PopupMenuItem;
-    private _appsSection: PopupMenu.PopupMenuSection;
+    _appSystem: typeof Shell.AppSystem;
+    _proxy: typeof BackgroundMonitorProxy | null;
+    _listTitle: PopupMenu.PopupMenuItem;
+    _appsSection: PopupMenu.PopupMenuSection;
 
     /**
      * Initializes a new instance of `BackgroundAppsToggle`.

--- a/packages/gnome-shell/src/ui/status/backlight.d.ts
+++ b/packages/gnome-shell/src/ui/status/backlight.d.ts
@@ -12,8 +12,8 @@ declare const BrightnessProxy: Gio.DBusProxy;
  * This class extends `PopupMenu.PopupBaseMenuItem`.
  */
 export declare class SliderItem extends PopupMenu.PopupBaseMenuItem {
-    private _slider: Slider;
-    private _sliderChangedId: number;
+    _slider: Slider;
+    _sliderChangedId: number;
 
     /**
      * Constructs a SliderItem.
@@ -36,7 +36,7 @@ export declare class SliderItem extends PopupMenu.PopupBaseMenuItem {
  * This class extends `St.BoxLayout`.
  */
 export declare class DiscreteItem extends St.BoxLayout {
-    private _levelButtons: Map<string, St.BoxLayout>;
+    _levelButtons: Map<string, St.BoxLayout>;
 
     /**
      * Constructs a DiscreteItem.
@@ -46,27 +46,27 @@ export declare class DiscreteItem extends St.BoxLayout {
     /**
      * Converts value to corresponding level.
      */
-    private _valueToLevel(value: number): string;
+    _valueToLevel(value: number): string;
 
     /**
      * Converts level to corresponding value.
      */
-    private _levelToValue(level: string): number;
+    _levelToValue(level: string): number;
 
     /**
      * Adds a level button to the item.
      */
-    private _addLevelButton(key: string, label: string, iconName: string): void;
+    _addLevelButton(key: string, label: string, iconName: string): void;
 
     /**
      * Synchronizes available levels based on `nLevels`.
      */
-    private _syncLevels(): void;
+    _syncLevels(): void;
 
     /**
      * Synchronizes the checked state based on value.
      */
-    private _syncChecked(): void;
+    _syncChecked(): void;
 }
 
 /**
@@ -74,9 +74,9 @@ export declare class DiscreteItem extends St.BoxLayout {
  * This class extends `QuickMenuToggle`.
  */
 export declare class KeyboardBrightnessToggle extends QuickMenuToggle {
-    private _proxy: typeof BrightnessProxy;
-    private _sliderItem: SliderItem;
-    private _discreteItem: DiscreteItem;
+    _proxy: typeof BrightnessProxy;
+    _sliderItem: SliderItem;
+    _discreteItem: DiscreteItem;
 
     /**
      * Initializes a new instance of `KeyboardBrightnessToggle`.
@@ -86,7 +86,7 @@ export declare class KeyboardBrightnessToggle extends QuickMenuToggle {
     /**
      * Synchronizes the toggle state with the brightness settings.
      */
-    private _sync(): void;
+    _sync(): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/status/bluetooth.d.ts
+++ b/packages/gnome-shell/src/ui/status/bluetooth.d.ts
@@ -13,12 +13,12 @@ import { QuickMenuToggle, SystemIndicator } from '../quickSettings.js';
  * Bluetooth client class, managing the state and devices of Bluetooth.
  */
 export declare class BtClient extends GObject.Object {
-    private _client: typeof GnomeBluetooth.Client;
-    private _proxy: Gio.DBusProxy;
-    private _adapter: any; // Replace with actual type
-    private _deviceNotifyConnected: Set<string>;
-    private _predictedState: GnomeBluetooth.AdapterState | undefined;
-    private _devicesChangedId?: number;
+    _client: typeof GnomeBluetooth.Client;
+    _proxy: Gio.DBusProxy;
+    _adapter: any; // Replace with actual type
+    _deviceNotifyConnected: Set<string>;
+    _predictedState: GnomeBluetooth.AdapterState | undefined;
+    _devicesChangedId?: number;
 
     /**
      * Initializes a new instance of `BtClient`.
@@ -60,12 +60,12 @@ export declare class BtClient extends GObject.Object {
  * Menu item representing a Bluetooth device.
  */
 export declare class BluetoothDeviceItem extends PopupMenu.PopupBaseMenuItem {
-    private _device: any; // Replace with actual type
-    private _client: BtClient;
-    private _icon: St.Icon;
-    private _label: St.Label;
-    private _subtitle: St.Label;
-    private _spinner: Spinner;
+    _device: any; // Replace with actual type
+    _client: BtClient;
+    _icon: St.Icon;
+    _label: St.Label;
+    _subtitle: St.Label;
+    _spinner: Spinner;
 
     /**
      * Constructs a `BluetoothDeviceItem`.
@@ -75,17 +75,17 @@ export declare class BluetoothDeviceItem extends PopupMenu.PopupBaseMenuItem {
     /**
      * Toggles the connected state of the device.
      */
-    private _toggleConnected(): Promise<void>;
+    _toggleConnected(): Promise<void>;
 }
 
 /**
  * Toggle for managing Bluetooth settings.
  */
 export declare class BluetoothToggle extends QuickMenuToggle {
-    private _client: BtClient;
-    private _deviceItems: Map<string, BluetoothDeviceItem>;
-    private _deviceSection: PopupMenu.PopupMenuSection;
-    private _placeholderItem: PopupMenu.PopupMenuItem;
+    _client: BtClient;
+    _deviceItems: Map<string, BluetoothDeviceItem>;
+    _deviceSection: PopupMenu.PopupMenuSection;
+    _placeholderItem: PopupMenu.PopupMenuItem;
 
     /** @hidden */
     _init(params: St.Button.ConstructorProps): void;
@@ -95,27 +95,27 @@ export declare class BluetoothToggle extends QuickMenuToggle {
      */
     _init(client: BtClient): void;
 
-    private _onActiveChanged(): void;
-    private _updatePlaceholder(): void;
-    private _updateDeviceVisibility(): void;
-    private _getSortedDevices(): any[]; // Replace with actual device array type
-    private _removeDevice(path: string): void;
-    private _reorderDeviceItems(): void;
-    private _sync(): void;
-    private _getIconNameFromState(state: GnomeBluetooth.AdapterState): string;
+    _onActiveChanged(): void;
+    _updatePlaceholder(): void;
+    _updateDeviceVisibility(): void;
+    _getSortedDevices(): any[]; // Replace with actual device array type
+    _removeDevice(path: string): void;
+    _reorderDeviceItems(): void;
+    _sync(): void;
+    _getIconNameFromState(state: GnomeBluetooth.AdapterState): string;
 }
 
 /**
  * System indicator for Bluetooth.
  */
 export declare class Indicator extends SystemIndicator {
-    private _client: BtClient;
-    private _indicator: any; // Replace with actual indicator type
+    _client: BtClient;
+    _indicator: any; // Replace with actual indicator type
 
     /**
      * Initializes a new instance of `Indicator`.
      */
     _init(): void;
 
-    private _sync(): void;
+    _sync(): void;
 }

--- a/packages/gnome-shell/src/ui/status/brightness.d.ts
+++ b/packages/gnome-shell/src/ui/status/brightness.d.ts
@@ -14,8 +14,8 @@ declare const BrightnessProxy: Gio.DBusProxy;
  * Extends `QuickSlider`.
  */
 export declare class BrightnessItem extends QuickSlider {
-    private _proxy: typeof BrightnessProxy;
-    private _sliderChangedId: number;
+    _proxy: typeof BrightnessProxy;
+    _sliderChangedId: number;
 
     /**
      * Initializes a new instance of `BrightnessItem`.
@@ -25,18 +25,18 @@ export declare class BrightnessItem extends QuickSlider {
     /**
      * Handles changes in the slider's value, updating brightness.
      */
-    private _sliderChanged(): void;
+    _sliderChanged(): void;
 
     /**
      * Updates the slider's value without triggering change events.
      * @param value - The new value to set for the slider.
      */
-    private _changeSlider(value: number): void;
+    _changeSlider(value: number): void;
 
     /**
      * Synchronizes the brightness with the system's current setting.
      */
-    private _sync(): void;
+    _sync(): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/status/camera.d.ts
+++ b/packages/gnome-shell/src/ui/status/camera.d.ts
@@ -8,8 +8,8 @@ import { SystemIndicator } from '../quickSettings.js';
  * System indicator for the camera status.
  */
 export declare class Indicator extends SystemIndicator {
-    private _indicator: St.Icon;
-    private _cameraMonitor: Shell.CameraMonitor;
+    _indicator: St.Icon;
+    _cameraMonitor: Shell.CameraMonitor;
 
     /**
      * Constructs a new instance of the camera indicator.

--- a/packages/gnome-shell/src/ui/status/darkMode.d.ts
+++ b/packages/gnome-shell/src/ui/status/darkMode.d.ts
@@ -9,8 +9,8 @@ import { QuickToggle, SystemIndicator } from '../quickSettings.js';
  * Extends `QuickToggle`.
  */
 export declare class DarkModeToggle extends QuickToggle {
-    private _settings: Gio.Settings;
-    private _changedId: number;
+    _settings: Gio.Settings;
+    _changedId: number;
 
     /**
      * Initializes a new instance of `DarkModeToggle`.
@@ -20,12 +20,12 @@ export declare class DarkModeToggle extends QuickToggle {
     /**
      * Toggles the dark mode setting.
      */
-    private _toggleMode(): void;
+    _toggleMode(): void;
 
     /**
      * Synchronizes the toggle state with the current dark mode setting.
      */
-    private _sync(): void;
+    _sync(): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/status/dwellClick.d.ts
+++ b/packages/gnome-shell/src/ui/status/dwellClick.d.ts
@@ -21,9 +21,9 @@ export interface DwellClickMode {
  * Extends `PanelMenu.Button`.
  */
 export declare class DwellClickIndicator extends PanelMenu.Button {
-    private _icon: St.Icon;
-    private _a11ySettings: Gio.Settings;
-    private _seat: Clutter.Seat;
+    _icon: St.Icon;
+    _a11ySettings: Gio.Settings;
+    _seat: Clutter.Seat;
 
     /**
      * Initializes a new instance of `DwellClickIndicator`.
@@ -33,24 +33,24 @@ export declare class DwellClickIndicator extends PanelMenu.Button {
     /**
      * Syncs the menu visibility based on the accessibility settings.
      */
-    private _syncMenuVisibility(): typeof GLib.SOURCE_REMOVE;
+    _syncMenuVisibility(): typeof GLib.SOURCE_REMOVE;
 
     /**
      * Adds a dwell action to the menu.
      * @param mode - The mode for the dwell action.
      */
-    private _addDwellAction(mode: { name: string; icon: string; type: DwellClickMode }): void;
+    _addDwellAction(mode: { name: string; icon: string; type: DwellClickMode }): void;
 
     /**
      * Updates the click type icon based on the provided click type.
      * @param manager - The Clutter manager.
      * @param clickType - The type of click.
      */
-    private _updateClickType(manager: any, clickType: DwellClickMode): void;
+    _updateClickType(manager: any, clickType: DwellClickMode): void;
 
     /**
      * Sets the click type for the dwell action.
      * @param mode - The mode to set for the click type.
      */
-    private _setClickType(mode: { type: DwellClickMode; icon: string }): void;
+    _setClickType(mode: { type: DwellClickMode; icon: string }): void;
 }

--- a/packages/gnome-shell/src/ui/status/keyboard.d.ts
+++ b/packages/gnome-shell/src/ui/status/keyboard.d.ts
@@ -34,7 +34,7 @@ export declare class InputSource extends Signals.EventEmitter {
     type: string;
     id: string;
     displayName: string;
-    private _shortName: string;
+    _shortName: string;
     index: number;
     properties: any; // Replace with appropriate type
     xkbId: string;
@@ -62,16 +62,16 @@ export declare class InputSource extends Signals.EventEmitter {
     /**
      * Generates the XKB ID.
      */
-    private _getXkbId(): string;
+    _getXkbId(): string;
 }
 
 /**
  * Class representing a popup for input sources.
  */
 export declare class InputSourcePopup extends SwitcherPopup.SwitcherPopup {
-    private _action: any; // Replace with appropriate type
-    private _actionBackward: any; // Replace with appropriate type
-    private _switcherList: InputSourceSwitcher;
+    _action: any; // Replace with appropriate type
+    _actionBackward: any; // Replace with appropriate type
+    _switcherList: InputSourceSwitcher;
 
     /** @hidden Only defined to resolve type conflict */
     _init(props: St.Widget.ConstructorProps): void;
@@ -138,13 +138,13 @@ export declare class InputSourceIndicatorContainer extends St.Widget {
  * Class representing an input source indicator.
  */
 export declare class InputSourceIndicator extends PanelMenu.Button {
-    private _menuItems: { [key: string]: LayoutMenuItem };
-    private _indicatorLabels: { [key: string]: St.Label };
-    private _container: InputSourceIndicatorContainer;
-    private _propSeparator: PopupMenu.PopupSeparatorMenuItem;
-    private _propSection: PopupMenu.PopupMenuSection;
-    private _showLayoutItem: any; // Replace with appropriate type
-    private _inputSourceManager: any; // Replace with appropriate type
+    _menuItems: { [key: string]: LayoutMenuItem };
+    _indicatorLabels: { [key: string]: St.Label };
+    _container: InputSourceIndicatorContainer;
+    _propSeparator: PopupMenu.PopupSeparatorMenuItem;
+    _propSection: PopupMenu.PopupMenuSection;
+    _showLayoutItem: any; // Replace with appropriate type
+    _inputSourceManager: any; // Replace with appropriate type
 
     /**
      * Initializes a new instance of `InputSourceIndicator`.

--- a/packages/gnome-shell/src/ui/status/location.d.ts
+++ b/packages/gnome-shell/src/ui/status/location.d.ts
@@ -47,8 +47,8 @@ export declare class GeoclueAgent extends GObject.Object {
  * Indicator for location services in the system status area.
  */
 export declare class Indicator extends SystemIndicator {
-    private _agent: GeoclueAgent;
-    private _indicator: St.Icon;
+    _agent: GeoclueAgent;
+    _indicator: St.Icon;
 
     constructor();
 }
@@ -62,11 +62,11 @@ export declare class AppAuthorizer {
     // Authorizes the app for location access.
     authorize(): Promise<GeoclueAccuracyLevel>;
     // Prompts user for authorization.
-    private _userAuthorizeApp(): Promise<void>;
+    _userAuthorizeApp(): Promise<void>;
     // Completes the authorization process.
-    private _completeAuth(): GeoclueAccuracyLevel;
+    _completeAuth(): GeoclueAccuracyLevel;
     // Saves the authorization decision to the permission store.
-    private _saveToPermissionStore(): Promise<void>;
+    _saveToPermissionStore(): Promise<void>;
 }
 
 /**
@@ -76,9 +76,9 @@ export declare class GeolocationDialog extends ModalDialog.ModalDialog {
     constructor(name: string, reason: string, reqAccuracyLevel: GeoclueAccuracyLevel);
 
     // Handles the 'Grant Access' action.
-    private _onGrantClicked(): void;
+    _onGrantClicked(): void;
     // Handles the 'Deny Access' action.
-    private _onDenyClicked(): void;
+    _onDenyClicked(): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/status/nightLight.d.ts
+++ b/packages/gnome-shell/src/ui/status/nightLight.d.ts
@@ -30,8 +30,8 @@ declare class NightLightToggle extends QuickToggle {
  * System indicator class for Night Light.
  */
 export declare class Indicator extends SystemIndicator {
-    private _indicator: any; // Replace with appropriate type.
-    private _proxy: Gio.DBusProxy;
+    _indicator: any; // Replace with appropriate type.
+    _proxy: Gio.DBusProxy;
 
     /**
      * Initialize the Night Light indicator.

--- a/packages/gnome-shell/src/ui/status/powerProfiles.d.ts
+++ b/packages/gnome-shell/src/ui/status/powerProfiles.d.ts
@@ -38,9 +38,9 @@ declare const LAST_PROFILE_KEY: string;
  * Class representing the toggle for Power Profiles in the system settings.
  */
 declare class PowerProfilesToggle extends QuickMenuToggle {
-    private _profileItems: Map<string, PopupMenu.PopupImageMenuItem>;
-    private _profileSection: PopupMenu.PopupMenuSection;
-    private _proxy: PowerProfilesProxy;
+    _profileItems: Map<string, PopupMenu.PopupImageMenuItem>;
+    _profileSection: PopupMenu.PopupMenuSection;
+    _proxy: PowerProfilesProxy;
 
     /**
      * Initialize a new Power Profiles toggle.

--- a/packages/gnome-shell/src/ui/status/remoteAccess.d.ts
+++ b/packages/gnome-shell/src/ui/status/remoteAccess.d.ts
@@ -17,8 +17,8 @@ declare const MIN_SHARED_INDICATOR_VISIBLE_TIME_US: number;
  * Class representing the Remote Access Applet.
  */
 export declare class RemoteAccessApplet extends SystemIndicator {
-    private _handles: Set<any>;
-    private _indicator: any;
+    _handles: Set<any>;
+    _indicator: any;
 
     /**
      * Initialize a new Remote Access Applet.
@@ -28,33 +28,33 @@ export declare class RemoteAccessApplet extends SystemIndicator {
     /**
      * Determine if recording is in progress.
      */
-    private _isRecording(): boolean;
+    _isRecording(): boolean;
 
     /**
      * Synchronize the applet's visibility.
      */
-    private _sync(): void;
+    _sync(): void;
 
     /**
      * Handle the stop event for a recording handle.
      */
-    private _onStopped(handle: any): void;
+    _onStopped(handle: any): void;
 
     /**
      * Handle a new recording handle.
      */
-    private _onNewHandle(handle: any): void;
+    _onNewHandle(handle: any): void;
 }
 
 /**
  * Class representing the Screen Recording Indicator.
  */
 export declare class ScreenRecordingIndicator extends PanelMenu.ButtonBox {
-    private _box: St.BoxLayout;
-    private _label: St.Label;
-    private _icon: St.Icon;
-    private _timeoutId: number;
-    private _secondsPassed: number;
+    _box: St.BoxLayout;
+    _label: St.Label;
+    _icon: St.Icon;
+    _timeoutId: number;
+    _secondsPassed: number;
 
     /**
      * Initialize a new Screen Recording Indicator.
@@ -69,23 +69,23 @@ export declare class ScreenRecordingIndicator extends PanelMenu.ButtonBox {
     /**
      * Update the label displaying recording time.
      */
-    private _updateLabel(): void;
+    _updateLabel(): void;
 
     /**
      * Handle changes in screencast progress.
      */
-    private _onScreencastInProgressChanged(): void;
+    _onScreencastInProgressChanged(): void;
 }
 
 /**
  * Class representing the Screen Sharing Indicator.
  */
 export declare class ScreenSharingIndicator extends PanelMenu.ButtonBox {
-    private _box: St.BoxLayout;
-    private _controller: any;
-    private _handles: Set<any>;
-    private _hideIndicatorId?: number;
-    private _visibleTimeUs?: number;
+    _box: St.BoxLayout;
+    _controller: any;
+    _handles: Set<any>;
+    _hideIndicatorId?: number;
+    _visibleTimeUs?: number;
 
     /**
      * Initialize a new Screen Sharing Indicator.
@@ -95,7 +95,7 @@ export declare class ScreenSharingIndicator extends PanelMenu.ButtonBox {
     /**
      * Handle a new screen sharing handle.
      */
-    private _onNewHandle(handle: any): void;
+    _onNewHandle(handle: any): void;
 
     /**
      * Override the default event handling.
@@ -105,15 +105,15 @@ export declare class ScreenSharingIndicator extends PanelMenu.ButtonBox {
     /**
      * Stop all ongoing screen sharing sessions.
      */
-    private _stopSharing(): void;
+    _stopSharing(): void;
 
     /**
      * Hide the screen sharing indicator.
      */
-    private _hideIndicator(): boolean;
+    _hideIndicator(): boolean;
 
     /**
      * Synchronize the visibility of the indicator.
      */
-    private _sync(): void;
+    _sync(): void;
 }

--- a/packages/gnome-shell/src/ui/status/rfkill.d.ts
+++ b/packages/gnome-shell/src/ui/status/rfkill.d.ts
@@ -20,7 +20,7 @@ declare const rfkillManagerInfo: Gio.DBusInterfaceInfo;
  * Class representing the RFKill Manager.
  */
 export declare class RfkillManager extends GObject.Object {
-    private _proxy: Gio.DBusProxy;
+    _proxy: Gio.DBusProxy;
 
     /**
      * Create a new RFKill Manager.
@@ -46,7 +46,7 @@ export declare class RfkillManager extends GObject.Object {
     /**
      * Handle changes in RFKill properties.
      */
-    private _changed(proxy: Gio.DBusProxy, properties: GLib.Variant): void;
+    _changed(proxy: Gio.DBusProxy, properties: GLib.Variant): void;
 }
 
 /**
@@ -58,7 +58,7 @@ export declare function getRfkillManager(): RfkillManager;
  * Class representing the RFKill Toggle in Quick Settings.
  */
 export declare class RfkillToggle extends QuickToggle {
-    private _manager: RfkillManager;
+    _manager: RfkillManager;
 
     /**
      * Initialize a new RFKill Toggle.
@@ -70,8 +70,8 @@ export declare class RfkillToggle extends QuickToggle {
  * Class representing the RFKill System Indicator.
  */
 export declare class Indicator extends SystemIndicator {
-    private _indicator: any;
-    private _rfkillToggle: RfkillToggle;
+    _indicator: any;
+    _rfkillToggle: RfkillToggle;
 
     /**
      * Initialize a new RFKill Indicator.
@@ -81,5 +81,5 @@ export declare class Indicator extends SystemIndicator {
     /**
      * Synchronize the indicator's visibility.
      */
-    private _sync(): void;
+    _sync(): void;
 }

--- a/packages/gnome-shell/src/ui/status/system.d.ts
+++ b/packages/gnome-shell/src/ui/status/system.d.ts
@@ -23,7 +23,7 @@ declare const PowerManagerProxy: Gio.DBusProxy;
  * A toggle for managing and displaying power-related settings.
  */
 declare class PowerToggle extends QuickToggle {
-    private _proxy: Gio.DBusProxy;
+    _proxy: Gio.DBusProxy;
 
     /**
      * Initializes a new instance of PowerToggle.
@@ -33,12 +33,12 @@ declare class PowerToggle extends QuickToggle {
     /**
      * Update the toggle based on session updates.
      */
-    private _sessionUpdated(): void;
+    _sessionUpdated(): void;
 
     /**
      * Synchronize the state of the toggle with the proxy data.
      */
-    private _sync(): void;
+    _sync(): void;
 }
 
 // ... other classes like ScreenshotItem, SettingsItem, ShutdownItem, LockItem ...
@@ -47,8 +47,8 @@ declare class PowerToggle extends QuickToggle {
  * A system item for quick settings, containing power, screenshot, settings, lock, and shutdown items.
  */
 declare class SystemItem extends QuickSettingsItem {
-    private _powerToggle: PowerToggle;
-    private _laptopSpacer: Clutter.Actor;
+    _powerToggle: PowerToggle;
+    _laptopSpacer: Clutter.Actor;
     // ... other private members
 
     /**
@@ -66,10 +66,10 @@ declare class SystemItem extends QuickSettingsItem {
  * The main system indicator for the GNOME Shell status area.
  */
 declare class Indicator extends SystemIndicator {
-    private _desktopSettings: Gio.Settings;
-    private _indicator: St.Icon;
-    private _percentageLabel: St.Label;
-    private _systemItem: SystemItem;
+    _desktopSettings: Gio.Settings;
+    _indicator: St.Icon;
+    _percentageLabel: St.Label;
+    _systemItem: SystemItem;
 
     /**
      * Initializes a new instance of Indicator.
@@ -79,7 +79,7 @@ declare class Indicator extends SystemIndicator {
     /**
      * Synchronize the indicator with the current state.
      */
-    private _sync(): void;
+    _sync(): void;
 }
 
 export { PowerToggle, SystemItem, Indicator };

--- a/packages/gnome-shell/src/ui/status/thunderbolt.d.ts
+++ b/packages/gnome-shell/src/ui/status/thunderbolt.d.ts
@@ -58,7 +58,7 @@ export const BoltDeviceProxy: Gio.DBusProxy;
  * Client class for interacting with Bolt service.
  */
 export class Client extends Signals.EventEmitter {
-    private _proxy: Gio.DBusProxy | null;
+    _proxy: Gio.DBusProxy | null;
     public probing: boolean;
 
     /**
@@ -69,17 +69,17 @@ export class Client extends Signals.EventEmitter {
     /**
      * Asynchronously gets the Bolt D-Bus proxy.
      */
-    private _getProxy(): Promise<void>;
+    _getProxy(): Promise<void>;
 
     /**
      * Handles changes in Bolt properties.
      */
-    private _onPropertiesChanged(proxy: any, properties: any): void;
+    _onPropertiesChanged(proxy: any, properties: any): void;
 
     /**
      * Handles the addition of new devices.
      */
-    private _onDeviceAdded(proxy: any, emitter: any, params: any): void;
+    _onDeviceAdded(proxy: any, emitter: any, params: any): void;
 
     /**
      * Closes the client and cleans up resources.
@@ -101,9 +101,9 @@ export class Client extends Signals.EventEmitter {
  * Helper class to automatically authorize new devices.
  */
 export class AuthRobot extends Signals.EventEmitter {
-    private _client: Client;
-    private _devicesToEnroll: any[];
-    private _enrolling: boolean;
+    _client: Client;
+    _devicesToEnroll: any[];
+    _enrolling: boolean;
 
     /**
      * Initializes a new instance of AuthRobot.
@@ -119,17 +119,17 @@ export class AuthRobot extends Signals.EventEmitter {
     /**
      * Handles the addition of new devices.
      */
-    private _onDeviceAdded(cli: any, dev: any): void;
+    _onDeviceAdded(cli: any, dev: any): void;
 
     /**
      * Starts the enrollment process for devices.
      */
-    private _enrollDevices(): void;
+    _enrollDevices(): void;
 
     /**
      * Idle callback for enrolling devices.
      */
-    private _enrollDevicesIdle(): Promise<void>;
+    _enrollDevicesIdle(): Promise<void>;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/status/thunderbolt.d.ts
+++ b/packages/gnome-shell/src/ui/status/thunderbolt.d.ts
@@ -59,7 +59,7 @@ export const BoltDeviceProxy: Gio.DBusProxy;
  */
 export class Client extends Signals.EventEmitter {
     _proxy: Gio.DBusProxy | null;
-    public probing: boolean;
+    probing: boolean;
 
     /**
      * Initializes a new instance of Client.

--- a/packages/gnome-shell/src/ui/status/volume.d.ts
+++ b/packages/gnome-shell/src/ui/status/volume.d.ts
@@ -19,16 +19,16 @@ export declare function getMixerControl(): Gvc.MixerControl;
  * StreamSlider class for controlling audio stream.
  */
 export declare class StreamSlider extends QuickSlider {
-    protected _control: Gvc.MixerControl;
-    protected _inDrag: boolean;
-    protected _notifyVolumeChangeId: number;
-    protected _soundSettings: Gio.Settings;
-    protected _sliderChangedId: number;
-    protected _stream: Gvc.MixerStream;
-    protected _volumeCancellable: Gio.Cancellable;
-    protected _icons: string[];
-    protected _deviceItems: Map<number, PopupMenu.PopupImageMenuItem>;
-    protected _deviceSection: PopupMenu.PopupMenuSection;
+    _control: Gvc.MixerControl;
+    _inDrag: boolean;
+    _notifyVolumeChangeId: number;
+    _soundSettings: Gio.Settings;
+    _sliderChangedId: number;
+    _stream: Gvc.MixerStream;
+    _volumeCancellable: Gio.Cancellable;
+    _icons: string[];
+    _deviceItems: Map<number, PopupMenu.PopupImageMenuItem>;
+    _deviceSection: PopupMenu.PopupMenuSection;
 
     /**
      * Initialize the StreamSlider.
@@ -46,30 +46,30 @@ export declare class StreamSlider extends QuickSlider {
      * Connects the stream for updates.
      * @param stream The Gvc.MixerStream object.
      */
-    protected _connectStream(stream: Gvc.MixerStream): void;
+    _connectStream(stream: Gvc.MixerStream): void;
 
     /**
      * Adds a device to the slider.
      * @param id The device ID.
      */
-    protected _addDevice(id: number): void;
+    _addDevice(id: number): void;
 
     /**
      * Removes a device from the slider.
      * @param id The device ID.
      */
-    protected _removeDevice(id: number): void;
+    _removeDevice(id: number): void;
 
     /**
      * Sets the active device.
      * @param activeId The active device ID.
      */
-    protected _setActiveDevice(activeId: number): void;
+    _setActiveDevice(activeId: number): void;
 
     /**
      * Updates the volume level.
      */
-    protected _updateVolume(): void;
+    _updateVolume(): void;
 
     // Additional methods and properties
 }
@@ -92,10 +92,10 @@ export declare class InputStreamSlider extends StreamSlider {
  * VolumeIndicator for system audio control.
  */
 export declare class VolumeIndicator extends SystemIndicator {
-    protected _indicator: Clutter.Actor;
-    protected _control: Gvc.MixerControl;
-    protected _output: OutputStreamSlider;
-    protected _input: InputStreamSlider;
+    _indicator: Clutter.Actor;
+    _control: Gvc.MixerControl;
+    _output: OutputStreamSlider;
+    _input: InputStreamSlider;
 
     /**
      * Handle scroll events for volume adjustment.
@@ -103,7 +103,7 @@ export declare class VolumeIndicator extends SystemIndicator {
      * @param event The Clutter scroll event.
      * @returns Clutter.EVENT_STOP or Clutter.EVENT_PROPAGATE
      */
-    protected _handleScrollEvent(item: StreamSlider, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
+    _handleScrollEvent(item: StreamSlider, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
 }
 
 /**


### PR DESCRIPTION
For context, see #66

A few notes:
- I haven't removed the explicit `public` modifiers, since they aren't a problem for extension developers, and they help the definitions to be more correct
- I've also left in the `readonly` modifiers, as I wasn't sure whether some of them were enforced (by setters or C code)