### PR TITLE
Fix yarn authentication in release CI (option 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "*"
 
+env:
+  NPM_TOKEN: ""
+
+
 jobs:
   build:
     name: Build CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   node-version: 22.x
+  NPM_TOKEN: ""
 
 jobs:
   release:
@@ -25,9 +26,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.node-version }}
-          registry-url: 'https://registry.npmjs.org'
-          # Defaults to the user or organization that owns the workflow file
-          scope: '@girs'
 
       - name: Install dependencies
         run: yarn install
@@ -41,4 +39,4 @@ jobs:
       - name: Publish 
         run: yarn workspace @girs/gnome-shell npm publish --tolerate-republish --access public --tag ${{github.event.release.prerelease && 'next' || 'latest'}} --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,6 @@ compressionLevel: mixed
 enableGlobalCache: false
 
 yarnPath: .yarn/releases/yarn-4.9.2.cjs
+
+npmRegistryServer: "https://registry.npmjs.org"
+npmAuthToken: "${NPM_TOKEN}"

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gjsify/gnome-shell-hello-world-example",
-  "version": "48.0.2",
+  "version": "48.0.3",
   "description": "Simple Gnome Shell Hello World Extension example",
   "type": "module",
   "main": "dist/extension.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gnome-shell",
-    "version": "48.0.2",
+    "version": "48.0.3",
     "description": "GJS TypeScript type definitions for GNOME Shell Extensions",
     "main": "src/index.js",
     "type": "module",

--- a/packages/gnome-shell/package.json
+++ b/packages/gnome-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@girs/gnome-shell",
-  "version": "48.0.2",
+  "version": "48.0.3",
   "description": "GJS TypeScript type definitions for GNOME Shell Extensions",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
This is a follow up of #64 

Since I tested #64 at the beginning with npm, setting the enviornment variable `NPM_TOKEN` was enough, as npm picked that up, but yarn doesn't do that and it needs the setting `npmAuthToken` in the `.yarnrc.yml` settings file to be set correctly. 

But when you use that in the CI, the release CI and build CI  fail, as `NPM_TOKEN` is not set everywhere, so it has a default empty value in the CI's .

I tested this entirely with a private registry and it works.


~~This is one possible fix of the release CI, see #72 for the 2. option (which doesn't work)~~