### PR TITLE
Add ease property and connect object types

### DIFF
--- a/packages/gnome-shell/src/extensions/global.d.ts
+++ b/packages/gnome-shell/src/extensions/global.d.ts
@@ -40,28 +40,58 @@ declare module '@girs/gobject-2.0/gobject-2.0' {
     export namespace GObject {
         interface Object {
             /**
+             * Connect one or more signals, and associate the handlers
+             * with a tracked object.
+             *
+             * All handlers for a particular object can be disconnected
+             * by calling disconnectObject(). If object is a {Clutter.widget},
+             * this is done automatically when the widget is destroyed.
+             *
+             * @param args - a sequence of signal-name/handler pairs
+             * with an optional flags value, followed by an object to track
+             *
              * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/54bc3aa4f54cb5452c29f81fada808224a18afa1/js/ui/environment.js#L245
              * @version 49
              */
             connectObject(...args: any[]): void;
 
             /**
+             * Connect one or more signals, and associate the handlers
+             * with a tracked object.
+             *
+             * All handlers for a particular object can be disconnected
+             * by calling disconnectObject(). If object is a {Clutter.widget},
+             * this is done automatically when the widget is destroyed.
+             *
+             * @param args - a sequence of signal-name/handler pairs
+             * with an optional flags value, followed by an object to track
+             *
              * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/54bc3aa4f54cb5452c29f81fada808224a18afa1/js/ui/environment.js#L248
              * @version 49
              */
             connect_object(...args: any[]): void;
 
             /**
+             * Disconnect all signals that were connected for
+             * the specified tracked object
+             *
+             * @param obj - the tracked object
+             *
              * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/54bc3aa4f54cb5452c29f81fada808224a18afa1/js/ui/environment.js#L251
              * @version 49
              */
-            disconnectObject(...args: any[]): void;
+            disconnectObject(obj: object): void;
 
             /**
+             * Disconnect all signals that were connected for
+             * the specified tracked object
+             *
+             * @param obj - the tracked object
+             *
              * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/54bc3aa4f54cb5452c29f81fada808224a18afa1/js/ui/environment.js#L254
              * @version 49
              */
-            disconnect_object(...args: any[]): void;
+            disconnect_object(obj: object): void;
         }
     }
 }

--- a/packages/gnome-shell/src/misc/signals.d.ts
+++ b/packages/gnome-shell/src/misc/signals.d.ts
@@ -75,11 +75,49 @@ export interface EventEmitter<S extends SignalMap<S> = any> extends SignalMethod
  * @version 47
  */
 export class EventEmitter<S extends SignalMap<S> = any> {
-    connectObject(...args: any[]): number; // TODO: return type is return type of imports.misc.signalTracker.connectObject
+    /**
+     * Connect one or more signals, and associate the handlers
+     * with a tracked object.
+     *
+     * All handlers for a particular object can be disconnected
+     * by calling disconnectObject(). If object is a {Clutter.widget},
+     * this is done automatically when the widget is destroyed.
+     *
+     * @param args - a sequence of signal-name/handler pairs
+     * with an optional flags value, followed by an object to track
+     * @returns
+     */
+    connectObject(...args: any[]): void;
 
-    disconnectObject(...args: any[]): number; // TODO: return type is return type of imports.misc.signalTracker.disconnectObject
+    /**
+     * Disconnect all signals that were connected for
+     * the specified tracked object
+     *
+     * @param obj - the tracked object
+     * @returns
+     */
+    disconnectObject(obj: object): void;
 
-    connect_object(...args: any[]): ReturnType<typeof this.connectObject>;
+    /**
+     * Connect one or more signals, and associate the handlers
+     * with a tracked object.
+     *
+     * All handlers for a particular object can be disconnected
+     * by calling disconnectObject(). If object is a {Clutter.widget},
+     * this is done automatically when the widget is destroyed.
+     *
+     * @param args - a sequence of signal-name/handler pairs
+     * with an optional flags value, followed by an object to track
+     * @returns
+     */
+    connect_object(...args: any[]): void;
 
-    disconnect_object(...args: any[]): ReturnType<typeof this.disconnectObject>;
+    /**
+     * Disconnect all signals that were connected for
+     * the specified tracked object
+     *
+     * @param obj - the tracked object
+     * @returns
+     */
+    disconnect_object(obj: object): void;
 }


### PR DESCRIPTION
Also updated documentation for existing connect object types.

There is also a way to properly types the args of the connectObject function, but I don't know if that is desired since the resulting type errors are non-descriptive.
```typescript
type Arguments<T extends any[]> =
    T extends [object]
        ? T
        : T extends [string, Function, ...infer T2]
            ? (T2 extends Arguments<T2> ? T : never)
            : never;

function connectObject<T extends any[]>(...args: Arguments<T>): void;
```