### PR TITLE
Add ibusManager types

### DIFF
--- a/packages/gnome-shell/src/misc/ibusManager.d.ts
+++ b/packages/gnome-shell/src/misc/ibusManager.d.ts
@@ -1,0 +1,25 @@
+import * as Signals from './signals.js';
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/ibusManager.js#L45
+ * @version 49
+ */
+export function getIBusManager(): IBusManager;
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/ibusManager.js#L51
+ * @version 49
+ */
+export namespace IBusManager {
+    interface SignalMap {
+        'set-cursor-location': [{ x: number; y: number; width: number; height: number }];
+        'focus-in': [];
+        'focus-out': [];
+    }
+}
+
+/**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/ibusManager.js#L51
+ * @version 49
+ */
+declare class IBusManager<S extends Signals.SignalMap<S> = IBusManager.SignalMap> extends Signals.EventEmitter<S> {}


### PR DESCRIPTION
Add types for IBusManager. I mainly use it for cursor focus tracking as is done in https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/keyboard.js.