### PR TITLE
Fix module resolution for gnome-shell

### DIFF
--- a/packages/gnome-shell/tsconfig.doc.json
+++ b/packages/gnome-shell/tsconfig.doc.json
@@ -2,8 +2,6 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         // General settings for code interpretation
-        "target": "ESNext",
-        "module": "ESNext",
         "noEmit": true,
         "baseUrl": "./",
         "rootDir": ".",

--- a/packages/gnome-shell/tsconfig.json
+++ b/packages/gnome-shell/tsconfig.json
@@ -1,11 +1,12 @@
 {
     "extends": "@tsconfig/strictest/tsconfig.json",
     "compilerOptions": {
+        // GJS 1.85.2 uses Spidermonkey 140 which supports most ESNext features.
         "lib": ["ESNext"],
         "types": [],
-        "target": "ESNext",
-        "module": "ESNext",
-        "moduleResolution": "Bundler",
+        "target": "esnext",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
         "skipLibCheck": false
     },
     "include": ["./dist/**/*.d.ts"]


### PR DESCRIPTION
Use nodenext as module and module resolution options.

I'm not sure why bundler was picked here, but I don't think it's the correct choice for a library which may or may not be bundled. Using nodenext enables stricter module resolution, and in particular enforces the use of file extensions for relative imports, thus avoiding regressions like those fixed in https://github.com/gjsify/gnome-shell/pull/82

Closes #86