### PR TITLE
ci: switch release publish to npm OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 
 env:
   node-version: 22.x
-  NPM_TOKEN: ""
 
 jobs:
   release:
@@ -21,7 +20,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      # This also setups a .npmrc file to publish to npm
+      # No registry-url: actions/setup-node would inject a NODE_AUTH_TOKEN
+      # placeholder that makes npm skip OIDC and fall back to token auth.
+      # The registry defaults to https://registry.npmjs.org.
       - name: Use Node.js ${{ env.node-version }}
         uses: actions/setup-node@v6
         with:
@@ -36,15 +37,7 @@ jobs:
       - name: Generate archive
         run: yarn workspace @girs/gnome-shell pack
 
-      - name: Configure Yarn for npm publishing
-        run: |
-          yarn config set npmRegistryServer "https://registry.npmjs.org"
-          yarn config set npmAlwaysAuth true
-          yarn config set npmAuthToken "${NPM_TOKEN}"
+      - name: Publish
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish 
-        run: yarn workspace @girs/gnome-shell npm publish --tolerate-republish --access public --tag ${{github.event.release.prerelease && 'next' || 'latest'}} --provenance
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || 'latest' }}
+        run: npm publish packages/gnome-shell --access public --provenance --tag "$PUBLISH_TAG"


### PR DESCRIPTION
## Problem

Release CI for `50.0.1` failed because `NPM_TOKEN` is empty/missing in the `npm-release` environment.

## Fix

Switch from Yarn token-based publishing to **npm OIDC Trusted Publishing** (no long-lived secret needed).

### What changed

- Remove `NPM_TOKEN` env var and secret references entirely
- Drop `registry-url` from `actions/setup-node` — when set, it injects a `NODE_AUTH_TOKEN` placeholder that makes npm skip OIDC and fall back to token auth (same pattern as gjsify/gjsify release.yml)
- Switch from `yarn workspace @girs/gnome-shell npm publish` (no OIDC support in Yarn) to `npm publish packages/gnome-shell` (npm CLI v10+ exchanges the GitHub OIDC token automatically)
- Move tag expression into an `env:` variable to avoid inline expression injection in `run:` commands

## Required follow-up on npmjs.com

Before re-running a release, configure a **Trusted Publisher** for `@girs/gnome-shell`:

1. Go to https://www.npmjs.com/package/@girs/gnome-shell/access
2. Add a Trusted Publisher with:
   - **Repository owner**: `gjsify`
   - **Repository name**: `gnome-shell`
   - **Workflow filename**: `release.yml`
   - **Environment**: `npm-release`

Once configured, re-publish by re-creating the `50.0.1` release or tagging a new version.