### PR TITLE
ci: add workflow_dispatch for manual re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release CI
 on:
   release:
     types: published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Publish tag (latest or next)'
+        required: false
+        default: 'latest'
 
 env:
   node-version: 22.x
@@ -39,5 +45,5 @@ jobs:
 
       - name: Publish
         env:
-          PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || 'latest' }}
+          PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || inputs.tag || 'latest' }}
         run: npm publish packages/gnome-shell --access public --provenance --tag "$PUBLISH_TAG"


### PR DESCRIPTION
Extends #101: adds `workflow_dispatch` trigger so the release can be manually re-run from `main` (which has the OIDC fix), bypassing the tag-commit limitation.

**Background**: GitHub uses the workflow from the tag's commit for `release` events. When a tag predates a workflow change, the old workflow runs. `workflow_dispatch` always uses the workflow from the selected ref (default: `main`).

The `tag` input defaults to `latest` and is ignored on `release` events (those use `prerelease` flag as before).