### PR TITLE
ci: fix npm provenance URL by cd-ing into package dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,6 @@ jobs:
       - name: Publish
         env:
           PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || inputs.tag || 'latest' }}
-        run: npm publish packages/gnome-shell --access public --provenance --tag "$PUBLISH_TAG"
+        run: |
+          cd packages/gnome-shell
+          npm publish --access public --provenance --tag "$PUBLISH_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release CI
 on:
   release:
     types: published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Publish tag (latest or next)'
+        required: false
+        default: 'latest'
 
 env:
   node-version: 22.x
@@ -39,5 +45,5 @@ jobs:
 
       - name: Publish
         env:
-          PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || 'latest' }}
+          PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || inputs.tag || 'latest' }}
         run: npm publish packages/gnome-shell --access public --provenance --tag "$PUBLISH_TAG"


### PR DESCRIPTION
`npm publish packages/gnome-shell --provenance` constructs the git-remote URL incorrectly when given a path argument: it produced `ssh://git@github.com/packages/gnome-shell.git` instead of the actual repo remote.

Fix: `cd packages/gnome-shell && npm publish` — npm resolves the git remote from the working directory instead.