### PR TITLE
ci: use actions/github-script to obtain OIDC token for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      # No registry-url: actions/setup-node would inject a NODE_AUTH_TOKEN
-      # placeholder that makes npm skip OIDC and fall back to token auth.
-      # The registry defaults to https://registry.npmjs.org.
       - name: Use Node.js ${{ env.node-version }}
         uses: actions/setup-node@v6
         with:
@@ -43,9 +40,26 @@ jobs:
       - name: Generate archive
         run: yarn workspace @girs/gnome-shell pack
 
+      - name: Get OIDC token
+        uses: actions/github-script@v7
+        id: oidc
+        with:
+          script: |
+            const token = await core.getIDToken('npm');
+            core.setSecret(token);
+            core.setOutput('token', token);
+
       - name: Publish
         env:
+          OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
           PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || inputs.tag || 'latest' }}
         run: |
-          cd packages/gnome-shell
-          npm publish --access public --provenance --tag "$PUBLISH_TAG"
+          NPM_TOKEN=$(curl -sSfL "https://registry.npmjs.org/-/npm/v1/oidc/token" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "{\"type\":\"oidc\",\"oidcToken\":\"${OIDC_TOKEN}\"}" | \
+            python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+          yarn config set npmRegistryServer "https://registry.npmjs.org"
+          yarn config set npmAlwaysAuth true
+          yarn config set npmAuthToken "${NPM_TOKEN}"
+          yarn workspace @girs/gnome-shell npm publish --tolerate-republish --access public --provenance --tag "${PUBLISH_TAG}"


### PR DESCRIPTION
Direct curl to `ACTIONS_ID_TOKEN_REQUEST_URL` returned 404. Use `core.getIDToken('npm')` via `actions/github-script` (the officially supported method) to get the JWT, then exchange it at the npm registry OIDC endpoint and configure Yarn with the short-lived token.