### PR TITLE
ci: fix npm OIDC token exchange endpoint and audience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: oidc
         with:
           script: |
-            const token = await core.getIDToken('npm');
+            const token = await core.getIDToken('npm:registry.npmjs.org');
             core.setSecret(token);
             core.setOutput('token', token);
 
@@ -54,10 +54,12 @@ jobs:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
           PUBLISH_TAG: ${{ github.event.release.prerelease && 'next' || inputs.tag || 'latest' }}
         run: |
-          NPM_TOKEN=$(curl -sSfL "https://registry.npmjs.org/-/npm/v1/oidc/token" \
+          NPM_TOKEN=$(curl -sSfL "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@girs%2fgnome-shell" \
             -X POST \
+            -H "Authorization: Bearer ${OIDC_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"type\":\"oidc\",\"oidcToken\":\"${OIDC_TOKEN}\"}" | \
+            -H "Accept: application/json" \
+            -d '{}' | \
             python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
           yarn config set npmRegistryServer "https://registry.npmjs.org"
           yarn config set npmAlwaysAuth true


### PR DESCRIPTION
## Problem

The OIDC token exchange was failing with HTTP 404 because:

1. **Wrong audience**: `'npm'` instead of `'npm:registry.npmjs.org'`
2. **Wrong endpoint**: `/-/npm/v1/oidc/token` instead of `/-/npm/v1/oidc/token/exchange/package/@girs%2fgnome-shell`
3. **Wrong request format**: OIDC token was in the JSON body, but npm expects it as `Authorization: Bearer <token>` with an empty `{}` body

## Fix

- Audience: `'npm'` → `'npm:registry.npmjs.org'`
- Endpoint: `/-/npm/v1/oidc/token` → `/-/npm/v1/oidc/token/exchange/package/@girs%2fgnome-shell`
- OIDC token: moved from request body to `Authorization: Bearer` header

These fixes are derived from the reference implementation in `gjsify/gjsify` at `packages/infra/cli/src/utils/npm-oidc.ts`.