### PR TITLE
ci: update actions/github-script from v7 to v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn workspace @girs/gnome-shell pack
 
       - name: Get OIDC token
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         id: oidc
         with:
           script: |


### PR DESCRIPTION
## Problem

`actions/github-script@v7` runs on Node.js 20 which is deprecated and will be forced to Node.js 24 starting 2026-06-16, with Node.js 20 removed from runners on 2026-09-16.

## Fix

Update `actions/github-script@v7` → `@v8` (Node.js 24).

Fixes annotation warning from run https://github.com/gjsify/gnome-shell/actions/runs/27642358445.