### PR TITLE
Export ExtensionObject type

### DIFF
--- a/packages/gnome-shell/src/ui/extensionSystem.d.ts
+++ b/packages/gnome-shell/src/ui/extensionSystem.d.ts
@@ -6,6 +6,8 @@ import * as Signals from '../misc/signals.js';
 import type { ExtensionType } from '../misc/extensionUtils.js';
 import type { ExtensionObject } from '../types/extension-object.js';
 
+export type { ExtensionObject };
+
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/dbusServices/extensions/extensionsService.js#L15
  * @version 49


### PR DESCRIPTION
It isn't exported from anywhere accessible (I belive).