### PR TITLE
Fix registerDestroyableType()

### DIFF
--- a/packages/gnome-shell/src/misc/signalTracker.d.ts
+++ b/packages/gnome-shell/src/misc/signalTracker.d.ts
@@ -107,7 +107,7 @@ export function disconnectObject(thisObj: object, obj: object): void;
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/misc/signalTracker.js#L266
  * @version 50
  */
-export function registerDestroyableType(gtype: GObject.Type): void;
+export function registerDestroyableType(gtype: GObject.GTypeInput): void;
 
 /**
  * A debug function that can be used to inspect signal trackers at run time


### PR DESCRIPTION
Needed to be `GType`. Used `GTypeInput` variant, since it seems to be the correct one for this exact use case.

Also. In the original JS code of this function:
```js
export function registerDestroyableType(gtype) {
    if (!GObject.type_is_a(gtype, GObject.Object))
        throw new Error(`${gtype} is not a GObject subclass`);

    if (!GObject.signal_lookup('destroy', gtype))
        throw new Error(`${gtype} does not have a destroy signal`);

    destroyableTypes.push(gtype);
}
```
With type checks, both `GObject.type_is_a` and `GObject.signal_lookup` shows a type error.

* `GObject.type_is_a` uses just `GObject.Object`
* `GObject.signal_lookup` uses `GObject.GType`

Probably both of them should be using `GTypeInput`.