### PR TITLE
Fix SignalMethods.connect callback return type

### DIFF
--- a/packages/gnome-shell/src/misc/signals.d.ts
+++ b/packages/gnome-shell/src/misc/signals.d.ts
@@ -41,7 +41,7 @@ export interface SignalMethods<S extends SignalMap<S> = any> {
      * @param callback A callback function
      * @returns A handler ID
      */
-    connect<Name extends keyof S>(sigName: Name, callback: (self: this, ...args: S[Name]) => boolean | undefined): number;
+    connect<Name extends keyof S>(sigName: Name, callback: (self: this, ...args: S[Name]) => boolean | void): number;
     /**
      * Emits a signal for an object. Emission stops if a signal handler returns `true`.
      *


### PR DESCRIPTION
`SignalMethods.connect` typed its callback return as `boolean | undefined`. That rejects the most common handler shape — one that returns nothing — because a void-returning function is **not** assignable to `boolean | undefined`:

```ts
events.connect('changed', () => {
    doSomething(); // returns void -> Type 'void' is not assignable to 'boolean | undefined'
});
```

Switching to `boolean | void` accepts both a void-returning handler and one that returns `true` to stop emission, which matches the `imports.signals` runtime semantics (only `true` stops emission — see [`_signals.js`](https://gitlab.gnome.org/GNOME/gjs/-/blob/master/modules/core/_signals.js#L134)).

Fixed here for now; the file already carries a `TODO` to upstream `SignalMethods` into `@girs/gjs`, where the same type lives — that's a separate change in the types generator.

Validated locally (`build:types`, `prettier:check`, `validate:types`, `validate:example`) — all green.

Closes #116
