### PR TITLE
Type PageManager's layout-changed signal

### DIFF
--- a/packages/gnome-shell/src/ui/appDisplay.d.ts
+++ b/packages/gnome-shell/src/ui/appDisplay.d.ts
@@ -163,10 +163,22 @@ export abstract class BaseAppView extends St.Widget {
 }
 
 /**
+ * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-50/js/ui/appDisplay.js#L1254
+ * @version 50
+ */
+declare namespace PageManager {
+    export interface SignalSignatures extends GObject.Object.SignalSignatures {
+        'layout-changed': () => void;
+    }
+}
+
+/**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-50/js/ui/appDisplay.js#L1256
  * @version 50
  */
 declare class PageManager extends GObject.Object {
+    $signals: PageManager.SignalSignatures;
+
     pages: { [appId: string]: { position: number } }[];
 
     _updatingPages: boolean;
@@ -177,6 +189,14 @@ declare class PageManager extends GObject.Object {
     _loadPages(): void;
 
     getAppPosition(appId: string): [number, number];
+
+    // Signal handler methods
+    connect<S extends PageManager.SignalSignatures, K extends keyof S>(signal: K, callback: GObject.SignalCallback<this, S[K]>): number;
+    connect_after<S extends PageManager.SignalSignatures, K extends keyof S>(signal: K, callback: GObject.SignalCallback<this, S[K]>): number;
+
+    // Generic signal handler methods
+    connect(signal: string, callback: (...args: any[]) => any): number;
+    connect_after(signal: string, callback: (...args: any[]) => any): number;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #124, addressing the typing nit I flagged during review.

`PageManager` defines a `layout-changed` signal ([`appDisplay.js#L1254`](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-50/js/ui/appDisplay.js#L1254)) that is connected internally ([`appDisplay.js#L1324`](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-50/js/ui/appDisplay.js#L1324)), but its typings omitted it — so `connect('layout-changed', …)` fell back to the generic `GObject.Object` overload instead of a typed one.

This adds a `SignalSignatures` namespace plus typed `connect`/`connect_after` overloads, mirroring the pattern already used for `BaseAppView`, `FolderIcon`, `AppIcon` and `AppFolderDialog` in the same file. Since `PageManager` is a non-exported `declare class`, the namespace is kept module-local as well (TypeScript requires the merged declarations to be consistently exported or local).

The other nit from the review — `_onScroll` typed with `Clutter.ScrollEvent` — is a `@girs` generation quirk (only the `Clutter.Event` union variant carries the field types), so it's out of scope here.

Validated locally with the full CI sequence (`build:types`, `prettier:check`, `validate:types`, `build:example`, `validate:example`) — all green.
