### PR TITLE
Add @girs dependency auto-update workflow

### DIFF
--- a/.github/workflows/update-girs.yml
+++ b/.github/workflows/update-girs.yml
@@ -1,0 +1,127 @@
+name: Update @girs
+
+on:
+  # Poll daily so a new ts-for-gir / @girs release is picked up automatically.
+  schedule:
+    - cron: "0 6 * * *"
+  # Manual run from the Actions tab.
+  workflow_dispatch:
+  # Optional instant trigger, e.g. from ts-for-gir's release workflow:
+  #   gh api repos/gjsify/gnome-shell/dispatches -f event_type=girs-release
+  repository_dispatch:
+    types: [girs-release]
+
+# Avoid overlapping runs racing on the same branch.
+concurrency:
+  group: update-girs
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  # The bump changes package.json, so the lockfile must be allowed to update.
+  YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
+
+jobs:
+  update-girs:
+    name: Update @girs
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Bump @girs dependencies to latest
+        run: node scripts/update-girs.mjs packages/gnome-shell/package.json examples/hello-world/package.json | tee "$RUNNER_TEMP/girs-changes.txt"
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet -- packages/gnome-shell/package.json examples/hello-world/package.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No @girs updates available."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true'
+        run: yarn install
+
+      - name: Validate
+        id: validate
+        if: steps.changes.outputs.changed == 'true'
+        continue-on-error: true
+        run: |
+          set -e
+          yarn run build:types
+          yarn run prettier:check
+          NODE_OPTIONS=--max_old_space_size=9216 yarn run validate:types
+          yarn run build:example
+          NODE_OPTIONS=--max_old_space_size=9216 yarn run validate:example
+
+      - name: Create or update pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VALIDATE_OUTCOME: ${{ steps.validate.outcome }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/update-girs"
+
+          if [ "$VALIDATE_OUTCOME" = "success" ]; then
+            STATUS="✅ Local validation (build + \`tsc\` + example) passed in this workflow run."
+            DRAFT_FLAG=""
+          else
+            STATUS="⚠️ **Validation failed** in this workflow run — the new @girs types likely need code changes in this repo. See the [workflow logs](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}). Opened as a draft."
+            DRAFT_FLAG="--draft"
+          fi
+
+          {
+            echo "Automated update of the \`@girs/*\` type dependencies to their latest npm \`latest\` dist-tag."
+            echo
+            echo "Versions are pinned exactly (no caret) on purpose — \`@girs\` encodes the library and ts-for-gir version in one semver string, so a stable suffix sorts *below* a release candidate and ranges resolve back to the rc. See \`scripts/update-girs.mjs\` for the full explanation."
+            echo
+            echo "$STATUS"
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/girs-changes.txt"
+            echo '```'
+            echo
+            echo "_Triggered by: \`${EVENT_NAME}\`._"
+            echo
+            echo "> Note: PRs opened by the default \`GITHUB_TOKEN\` do not trigger the Build CI workflow. Validation already ran inside this update workflow; close and reopen the PR if you want a separate Build CI run."
+          } > "$RUNNER_TEMP/pr-body.md"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$BRANCH"
+          git add -A
+          git commit -m "chore: update @girs dependencies to latest"
+          git push -f origin "$BRANCH"
+
+          EXISTING="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" --body-file "$RUNNER_TEMP/pr-body.md"
+            echo "Updated existing PR #$EXISTING"
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore: update @girs dependencies to latest" \
+              --body-file "$RUNNER_TEMP/pr-body.md" $DRAFT_FLAG
+          fi

--- a/.github/workflows/update-girs.yml
+++ b/.github/workflows/update-girs.yml
@@ -96,7 +96,7 @@ jobs:
           {
             echo "Automated update of the \`@girs/*\` type dependencies to their latest npm \`latest\` dist-tag."
             echo
-            echo "Versions are pinned exactly (no caret) on purpose — \`@girs\` encodes the library and ts-for-gir version in one semver string, so a stable suffix sorts *below* a release candidate and ranges resolve back to the rc. See \`scripts/update-girs.mjs\` for the full explanation."
+            echo "Dependencies use caret ranges (\`^x.y.z\`) on the release-only \`@girs\` version scheme (ts-for-gir >= 4.1): a caret dedupes across stable releases and excludes prereleases. This job advances the caret floor to the latest release. See \`scripts/update-girs.mjs\` for the full explanation."
             echo
             echo "$STATUS"
             echo

--- a/.github/workflows/update-girs.yml
+++ b/.github/workflows/update-girs.yml
@@ -1,9 +1,9 @@
 name: Update @girs
 
 on:
-  # Poll daily so a new ts-for-gir / @girs release is picked up automatically.
+  # Poll weekly so a new ts-for-gir / @girs release is picked up automatically.
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 * * 1"
   # Manual run from the Actions tab.
   workflow_dispatch:
   # Optional instant trigger, e.g. from ts-for-gir's release workflow:
@@ -68,9 +68,9 @@ jobs:
           set -e
           yarn run build:types
           yarn run prettier:check
-          NODE_OPTIONS=--max_old_space_size=9216 yarn run validate:types
+          yarn run validate:types
           yarn run build:example
-          NODE_OPTIONS=--max_old_space_size=9216 yarn run validate:example
+          yarn run validate:example
 
       - name: Create or update pull request
         if: steps.changes.outputs.changed == 'true'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "build:example": "yarn workspace @gjsify/gnome-shell-hello-world-example build",
         "build:types": "yarn workspace @girs/gnome-shell build",
         "prettier:check": "prettier --check .",
-        "prettier:fix": "prettier --write ."
+        "prettier:fix": "prettier --write .",
+        "update:girs": "node scripts/update-girs.mjs packages/gnome-shell/package.json examples/hello-world/package.json"
     },
     "gitHooks": {
         "pre-commit": "yarn run prettier:check"

--- a/scripts/update-girs.mjs
+++ b/scripts/update-girs.mjs
@@ -1,0 +1,73 @@
+// Pin every @girs/* dependency in the given package.json files to its npm
+// `latest` dist-tag, as an EXACT version (no caret/tilde range).
+//
+// Why exact pins?
+// @girs versions concatenate the library version and the ts-for-gir version into
+// a single semver string, e.g. "2.88.0-4.0.4". That makes the ts-for-gir part a
+// *prerelease tag*. By semver precedence a stable suffix like "-4.0.4" sorts
+// LOWER than a release-candidate suffix like "-4.0.0-rc.17" (a numeric identifier
+// such as "4" has lower precedence than an alphanumeric one such as "0-rc"). As a
+// result any caret/tilde range happily resolves back to the newest release
+// candidate and the `latest` dist-tag is never selected. Exact pins are the only
+// reliable way to track the stable releases — and it matches how the @girs
+// packages pin their own siblings.
+//
+// Scope: only updates the version of @girs/* keys that already exist. It does not
+// add, remove or rename packages (namespace changes like cogl-2.0 -> cogl-18 are
+// rare correctness fixes and stay manual), and it never touches protocol
+// specifiers such as "workspace:".
+//
+// Usage: node scripts/update-girs.mjs <package.json> [<package.json> ...]
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+    console.error('usage: node scripts/update-girs.mjs <package.json> [<package.json> ...]');
+    process.exit(2);
+}
+
+// "@girs/<name>": "<version-or-range>"
+const re = /(["']@girs\/[^"']+["']\s*:\s*["'])([^"']+)(["'])/g;
+
+const cache = new Map();
+const allChanges = [];
+
+function latestVersion(name) {
+    if (cache.has(name)) return cache.get(name);
+    let version = '';
+    try {
+        // execFileSync (no shell) — the package name is never passed through a shell.
+        version = execFileSync('npm', ['view', name, 'dist-tags.latest'], { encoding: 'utf8' }).trim();
+    } catch {
+        version = '';
+    }
+    cache.set(name, version);
+    return version;
+}
+
+for (const file of files) {
+    let text = readFileSync(file, 'utf8');
+    text = text.replace(re, (full, pre, ver, post) => {
+        const name = pre.match(/@girs\/[^"']+/)[0];
+        // Leave protocol-based specifiers untouched (workspace:, npm:, file:, link:, …).
+        if (ver.includes(':')) return full;
+        const latest = latestVersion(name);
+        if (!latest) {
+            console.error(`WARN: could not resolve latest for ${name}, leaving as "${ver}"`);
+            return full;
+        }
+        if (latest !== ver) allChanges.push(`${name}: ${ver} -> ${latest}`);
+        return pre + latest + post;
+    });
+    writeFileSync(file, text);
+}
+
+if (allChanges.length) {
+    // De-duplicate (the same package can appear in more than one file).
+    for (const line of [...new Set(allChanges)].sort()) console.log(line);
+    console.log(`\n${new Set(allChanges).size} dependency change(s)`);
+} else {
+    console.log('All @girs dependencies already up to date.');
+}

--- a/scripts/update-girs.mjs
+++ b/scripts/update-girs.mjs
@@ -1,16 +1,20 @@
-// Pin every @girs/* dependency in the given package.json files to its npm
-// `latest` dist-tag, as an EXACT version (no caret/tilde range).
+// Bump every @girs/* dependency in the given package.json files to a caret range
+// (`^x.y.z`) on its npm `latest` dist-tag.
 //
-// Why exact pins?
-// @girs versions concatenate the library version and the ts-for-gir version into
-// a single semver string, e.g. "2.88.0-4.0.4". That makes the ts-for-gir part a
-// *prerelease tag*. By semver precedence a stable suffix like "-4.0.4" sorts
-// LOWER than a release-candidate suffix like "-4.0.0-rc.17" (a numeric identifier
-// such as "4" has lower precedence than an alphanumeric one such as "0-rc"). As a
-// result any caret/tilde range happily resolves back to the newest release
-// candidate and the `latest` dist-tag is never selected. Exact pins are the only
-// reliable way to track the stable releases — and it matches how the @girs
-// packages pin their own siblings.
+// Why caret ranges?
+// Since ts-for-gir 4.1 (gjsify/ts-for-gir#432) @girs packages version as the
+// ts-for-gir release alone (e.g. "4.1.0"; the targeted library version lives in a
+// `libraryVersion` field). On that release-only scheme a caret range dedupes
+// across stable releases AND excludes prereleases (`4.2.0-rc.1` does not satisfy
+// `^4.1.0`) — on Yarn 4 too. It also matches how the @girs packages now pin their
+// own siblings (e.g. `@girs/clutter-18` -> `"@girs/gobject-2.0": "^4.1.0"`), so
+// transitive resolution dedupes to a single copy.
+//
+// This job advances the caret *floor* to the latest release: it refreshes the
+// declared minimum and gives the workflow a concrete diff to validate the new
+// types against. Exact pins are deliberately avoided — an exact top-level pin
+// re-diverges from the transitive `^x` deps as soon as a newer patch ships, which
+// re-opens the duplicate-copy issue (gjsify/ts-for-gir#431).
 //
 // Scope: only updates the version of @girs/* keys that already exist. It does not
 // add, remove or rename packages (namespace changes like cogl-2.0 -> cogl-18 are
@@ -58,8 +62,10 @@ for (const file of files) {
             console.error(`WARN: could not resolve latest for ${name}, leaving as "${ver}"`);
             return full;
         }
-        if (latest !== ver) allChanges.push(`${name}: ${ver} -> ${latest}`);
-        return pre + latest + post;
+        // Caret on the release-only version (dedupes stable releases, excludes rc).
+        const next = `^${latest}`;
+        if (next !== ver) allChanges.push(`${name}: ${ver} -> ${next}`);
+        return pre + next + post;
     });
     writeFileSync(file, text);
 }


### PR DESCRIPTION
Automates keeping the `@girs/*` type dependencies current, so we don't have to bump them by hand after every ts-for-gir release.

## How it works

- **Weekly** schedule (Mon 06:00 UTC) + `workflow_dispatch` + a `girs-release` `repository_dispatch` for an instant trigger from ts-for-gir's release workflow.
- `scripts/update-girs.mjs` bumps every `@girs/*` dep to `^<latest>` (caret on the npm `latest` dist-tag). The workflow then installs, runs the full validation (`build:types`, `prettier:check`, `validate:types`, `build:example`, `validate:example`) and opens/updates a PR — as a **draft** if validation fails, so type-affecting upgrades are flagged rather than merged blindly.

## Why caret ranges

Since gjsify/ts-for-gir#432 (released as 4.1) `@girs/*` versions as the ts-for-gir release alone (release-only scheme). On that scheme a caret range **dedupes** across stable releases **and excludes** prereleases (`4.2.0-rc.1` does not satisfy `^4.1.0`) — on Yarn 4 too.

Exact top-level pins are deliberately avoided: they re-diverge from the transitive `^x` deps of the `@girs` packages as soon as a newer `@girs` patch ships, which re-opens the duplicate-copy issue (ts-for-gir#431). The updater therefore advances the caret **floor** to the latest release — this refreshes the declared minimum and gives the workflow a concrete diff to validate the new types against.

Verified locally: emits `^4.1.0`, is idempotent (no-op on a second run, so no PR churn), and leaves `workspace:` specifiers untouched.

The namespace fix (`@girs/cogl-2.0` → `@girs/cogl-18`, #126 / #132) stays manual — the script only bumps versions of existing keys, it doesn't add/remove/rename packages. The first scheduled run will bump the deps off the release candidates, addressing #125.
