### PR TITLE
Loosen actor type on PopupMenuSection

### DIFF
--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -370,7 +370,7 @@ export namespace PopupMenuSection {
  * @version 49
  */
 export class PopupMenuSection<S extends Signals.SignalMap<S> = PopupMenuSection.SignalMap> extends PopupMenuBase<S> {
-    override readonly actor: St.BoxLayout;
+    override readonly actor: Clutter.Actor;
 
     constructor();
 


### PR DESCRIPTION
`PopupMenuSection` does set actor to a `St.BoxLayout` in its constuctor, it does not use it (nor any other code assumes it as a `St.BoxLayout`), but if I want to modify it in a subclass, it is now limited to subclass of `St.BoxLayout` instead of `Clutter.Actor` (which is from the parent class).

I would like to loosen this requirement. Especially since the only thing it does is
```
this.actor = this.box;
```
and the `St.BoxLayout` is still accessible via `this.box` property