### PR TITLE
Match the declarations to GNOME Shell 51

### DIFF
--- a/packages/gnome-shell/src/ui/appDisplay.d.ts
+++ b/packages/gnome-shell/src/ui/appDisplay.d.ts
@@ -117,7 +117,13 @@ export abstract class BaseAppView extends St.Widget {
 
     _onDestroy(): void;
     _createGrid(): AppGrid;
-    _onScroll(actor: St.ScrollView, event: Clutter.ScrollEvent): boolean;
+    /**
+     * Handles the `scroll` signal of the page's scroll controller. GNOME 51
+     * replaced the old `(actor, event)` handler with these arguments.
+     *
+     * @version 51
+     */
+    _onScroll(controller: Clutter.ScrollController, sprite: Clutter.Sprite, source: Clutter.ScrollSource, dx: number, dy: number): void;
     _swipeBegin(tracker: any, monitor: Clutter.EventSequence): void;
     _swipeUpdate(tracker: any, progress: number): void;
     _swipeEnd(tracker: any, duration: number, endProgress: number): void;
@@ -226,8 +232,13 @@ export class AppDisplay extends BaseAppView {
     _getItemPosition(item: AppViewItem): [number, number];
     _compareItems(a: AppViewItem, b: AppViewItem): number;
     _loadApps(): AppViewItem[];
-    _onScroll(actor: St.ScrollView, event: Clutter.ScrollEvent): boolean;
-    _onKeyPressEvent(actor: St.Widget, event: Clutter.KeyEvent): boolean;
+    /**
+     * Handles the `scroll` signal of the page's scroll controller. GNOME 51
+     * replaced the old `(actor, event)` handler with these arguments.
+     *
+     * @version 51
+     */
+    _onScroll(controller: Clutter.ScrollController, sprite: Clutter.Sprite, source: Clutter.ScrollSource, dx: number, dy: number): void;
     _maybeMoveItem(dragEvent: DragEvent): void;
     /** @hidden */
     _onDragBegin(): void;

--- a/packages/gnome-shell/src/ui/appFavorites.d.ts
+++ b/packages/gnome-shell/src/ui/appFavorites.d.ts
@@ -9,7 +9,6 @@ declare class AppFavorites extends EventEmitter {
 
     constructor();
 
-    _onFavsChanged(): void;
     _getIds(): string[];
     _addFavorite(appId: string, pos: number): void;
     _removeFavorite(appId: string): void;

--- a/packages/gnome-shell/src/ui/boxpointer.d.ts
+++ b/packages/gnome-shell/src/ui/boxpointer.d.ts
@@ -27,8 +27,8 @@ export class BoxPointer extends St.Widget {
     _border: St.DrawingArea;
     _arrowAlignment: number;
     _sourceAlignment: number;
-    _muteKeys: boolean;
-    _muteInput: boolean;
+    _muteKeys: Clutter.KeyController;
+    _muteInput: Clutter.ClickGesture;
     _sourceActor: Clutter.Actor | null;
     _sourceExtents: ReturnType<typeof Clutter.Actor.prototype.get_transformed_extents>;
     _workArea: ReturnType<typeof LayoutManager.prototype.getWorkAreaForMonitor>;
@@ -50,8 +50,6 @@ export class BoxPointer extends St.Widget {
      * @param binProperties Properties to set on contained bin
      */
     _init(arrowSide: St.Side, binProperties?: Partial<St.Bin.ConstructorProps>): void;
-
-    vfunc_captured_event(event: Clutter.Event): boolean;
 
     vfunc_get_preferred_width(forHeight: number): [number, number];
 

--- a/packages/gnome-shell/src/ui/calendar.d.ts
+++ b/packages/gnome-shell/src/ui/calendar.d.ts
@@ -154,7 +154,13 @@ export class Calendar extends St.Widget {
 
     updateTimeZone(): void;
 
-    vfunc_scroll_event(event: Clutter.ScrollEvent): boolean;
+    /**
+     * Handles the `scroll` signal of the calendar's scroll controller, which
+     * flips to the previous or next month.
+     *
+     * @version 51
+     */
+    _onScroll(controller: Clutter.ScrollController, sprite: Clutter.Sprite, source: Clutter.ScrollSource, dx: number, dy: number): void;
 
     _buildHeader(): void;
     _onPrevMonthButtonClicked(): void;

--- a/packages/gnome-shell/src/ui/calendar.d.ts
+++ b/packages/gnome-shell/src/ui/calendar.d.ts
@@ -5,7 +5,6 @@ import type Gio from '@girs/gio-2.0';
 import type St from '@girs/st-51';
 import type Clutter from '@girs/clutter-51';
 
-import type { Switch } from './popupMenu.js';
 import type { MessageView } from './messageList.js';
 
 declare function sameYear(dateA: Date, dateB: Date): boolean;
@@ -180,17 +179,6 @@ declare class Placeholder extends St.BoxLayout {
     _init(): void;
 }
 
-declare class DoNotDisturbSwitch extends Switch {
-    _settings: Gio.Settings;
-
-    constructor();
-    /** @hidden */
-    override _init(config?: Partial<St.Bin.ConstructorProps>): void;
-    /** @hidden */
-    override _init(state: boolean): void;
-    _init(): void;
-}
-
 /**
  * @see https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/calendar.js#L799
  * @version 48
@@ -199,8 +187,6 @@ declare class DoNotDisturbSwitch extends Switch {
 export class CalendarMessageList extends St.Widget {
     _placeholder: Placeholder;
     _scrollView: St.ScrollView;
-    _dndSwitch: DoNotDisturbSwitch;
-    _dndButton: St.Button;
     _clearButton: St.Button;
     _messageView: MessageView;
 

--- a/packages/gnome-shell/src/ui/dialog.d.ts
+++ b/packages/gnome-shell/src/ui/dialog.d.ts
@@ -30,7 +30,6 @@ export class Dialog extends St.Widget {
 
     _init(parentActor: St.Widget, styleClass?: string | null): void;
     makeInactive(): void;
-    vfunc_event(event: Clutter.Event): boolean;
     addButton(buttonInfo: ButtonInfo): St.Button;
     clearButtons(): void;
 

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -112,7 +112,6 @@ declare class ScreenTransition extends Clutter.Actor {
  * @version 48
  */
 declare class HotCorner extends Clutter.Actor {
-    _entered: boolean;
     _monitor: Monitor;
     _x: number;
     _y: number;
@@ -127,11 +126,8 @@ declare class HotCorner extends Clutter.Actor {
     setBarrierSize(size: number): void;
     handleDragOver(source: any, actor: any, x: number, y: number, time: number): DragMotionResult;
 
-    _setupFallbackCornerIfNeeded(layoutManager: LayoutManager): void;
     _onDestroy(): void;
     _toggleOverview(): void;
-    _onCornerEntered(): void;
-    _onCornerLeft(actor: Clutter.Actor, event: Clutter.Event): void;
 }
 
 /**
@@ -158,7 +154,6 @@ export class LayoutManager extends GObject.Object {
     _keyboardHeightNotifyId: number;
     _backgroundGroup: Meta.BackgroundGroup;
     _interfaceSettings: Gio.Settings;
-    _pendingLoadBackground: boolean;
     _systemBackground: SystemBackground;
 
     readonly _startingUp: boolean;

--- a/packages/gnome-shell/src/ui/layout.d.ts
+++ b/packages/gnome-shell/src/ui/layout.d.ts
@@ -126,7 +126,6 @@ declare class HotCorner extends Clutter.Actor {
 
     setBarrierSize(size: number): void;
     handleDragOver(source: any, actor: any, x: number, y: number, time: number): DragMotionResult;
-    vfunc_leave_event(event: Clutter.Event): boolean;
 
     _setupFallbackCornerIfNeeded(layoutManager: LayoutManager): void;
     _onDestroy(): void;

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -21,8 +21,21 @@ export class URLHighlighter extends St.Label {
 
     vfunc_button_press_event(buttonEvent: Clutter.ButtonEvent): boolean;
     vfunc_button_release_event(buttonEvent: Clutter.ButtonEvent): boolean;
-    vfunc_motion_event(motionEvent: Clutter.MotionEvent): boolean;
-    vfunc_leave_event(crossingEvent: Clutter.CrossingEvent): boolean;
+    /**
+     * Handles the `motion` signal of the label's motion controller, which sets
+     * the pointer cursor over a URL.
+     *
+     * @version 51
+     */
+    _onMotion(controller: Clutter.MotionController, sprite: Clutter.Sprite, x: number, y: number): void;
+
+    /**
+     * Handles the `leave` signal of the same controller and restores the
+     * default cursor.
+     *
+     * @version 51
+     */
+    _onLeave(): void;
     setMarkup(text?: string, allowMarkup?: boolean): void;
 
     _highlightUrls(): void;
@@ -117,7 +130,13 @@ export class Message extends St.Button {
 
     canClose(): boolean;
 
-    vfunc_key_press_event(keyEvent: Clutter.KeyEvent): boolean;
+    /**
+     * Closes the message if its notification allows it. The BackSpace and
+     * Delete key bindings call this.
+     *
+     * @version 51
+     */
+    _closeIfAllowed(): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/messageList.d.ts
+++ b/packages/gnome-shell/src/ui/messageList.d.ts
@@ -19,8 +19,6 @@ export class URLHighlighter extends St.Label {
     _init(params?: Partial<St.Label.ConstructorProps>): void;
     _init(text?: string, lineWrap?: boolean, allowMarkup?: boolean): void;
 
-    vfunc_button_press_event(buttonEvent: Clutter.ButtonEvent): boolean;
-    vfunc_button_release_event(buttonEvent: Clutter.ButtonEvent): boolean;
     /**
      * Handles the `motion` signal of the label's motion controller, which sets
      * the pointer cursor over a URL.
@@ -152,16 +150,11 @@ export class NotificationMessage extends Message {
 
     vfunc_clicked(): void;
     canClose(): boolean;
-
-    _getIcon(): St.Icon;
-    _onUpdated(n: Notification, _clear?: boolean): void;
 }
 
 declare class MediaMessage extends Message {
     _player: MprisPlayer;
     _icon: St.Icon;
-    _secondaryBin: St.Bin;
-    _closeButton: St.Button;
     _prevButton: St.Button;
     _playPauseButton: St.Button;
     _nextButton: St.Button;

--- a/packages/gnome-shell/src/ui/messageTray.d.ts
+++ b/packages/gnome-shell/src/ui/messageTray.d.ts
@@ -340,7 +340,6 @@ export class MessageTray extends St.Widget {
     _onDragBegin(): void;
     _onDragEnd(): void;
 
-    _onNotificationKeyRelease(actor: St.Widget, event: Clutter.Event): boolean;
     _expireNotification(): void;
     _addSource(source: Source): void;
     _removeSource(source: Source): void;

--- a/packages/gnome-shell/src/ui/messageTray.d.ts
+++ b/packages/gnome-shell/src/ui/messageTray.d.ts
@@ -345,7 +345,6 @@ export class MessageTray extends St.Widget {
     _removeSource(source: Source): void;
     _onSourceEnableChanged(policy: NotificationPolicy, source: Source): void;
     _onNotificationRemoved(source: Source, notification: Notification): void;
-    _onNotificationShow(_source: Source, notification: Notification): void;
     _resetNotificationLeftTimeout(): void;
     _onNotificationHoverChanged(): void;
     _onStatusChanged(status: PresenceStatus): void;

--- a/packages/gnome-shell/src/ui/modalDialog.d.ts
+++ b/packages/gnome-shell/src/ui/modalDialog.d.ts
@@ -80,7 +80,6 @@ export class ModalDialog extends St.Widget {
     _fadeOutDialog(timestamp: number): void;
 
     vfunc_key_press_event(event: Clutter.Event): boolean;
-    vfunc_captured_event(event: Clutter.Event): boolean;
 
     clearButtons(): void;
     setButtons(buttons: ButtonInfo[]): void;

--- a/packages/gnome-shell/src/ui/popupMenu.d.ts
+++ b/packages/gnome-shell/src/ui/popupMenu.d.ts
@@ -141,9 +141,7 @@ export class Switch extends St.Widget {
     _startDragging(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
     override vfunc_motion_event(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
     override vfunc_button_release_event(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
-    _touchDragging(actor: Clutter.Actor, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
     _endDragging(): typeof Clutter.EVENT_PROPAGATE;
-    _motionEvent(actor: Clutter.Actor, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
 
     // General signal handler methods
     connect(sigName: string, callback: (...args: any[]) => void): number;

--- a/packages/gnome-shell/src/ui/search.d.ts
+++ b/packages/gnome-shell/src/ui/search.d.ts
@@ -2,6 +2,7 @@
 
 import type St from '@girs/st-51';
 import type Clutter from '@girs/clutter-51';
+import type GObject from '@girs/gobject-2.0';
 
 import { AppSearchProvider } from './appDisplay.js';
 
@@ -14,6 +15,30 @@ export interface MetaInfo {
     createIcon?: (size: number) => Clutter.Actor;
     description?: string;
     clipboardText?: string;
+}
+
+export namespace SearchEntry {
+    export interface SignalSignatures extends St.Entry.SignalSignatures {
+        'activate-new-instance': () => void;
+    }
+}
+
+/**
+ * The overview's search entry. Ctrl+Enter emits `activate-new-instance` rather
+ * than activating the selected result.
+ *
+ * @version 51
+ */
+export class SearchEntry extends St.Entry {
+    $signals: SearchEntry.SignalSignatures;
+
+    // Signal handler methods
+    connect<S extends SearchEntry.SignalSignatures, K extends keyof S>(signal: K, callback: GObject.SignalCallback<this, S[K]>): number;
+    connect_after<S extends SearchEntry.SignalSignatures, K extends keyof S>(signal: K, callback: GObject.SignalCallback<this, S[K]>): number;
+
+    // Generic signal handler methods
+    connect(signal: string, callback: (...args: any[]) => any): number;
+    connect_after(signal: string, callback: (...args: any[]) => any): number;
 }
 
 export class MaxWidthBox extends St.BoxLayout {}

--- a/packages/gnome-shell/src/ui/search.d.ts
+++ b/packages/gnome-shell/src/ui/search.d.ts
@@ -150,7 +150,6 @@ export class SearchResultsView extends St.BoxLayout {
     _doProviderSearch(provider: AppSearchProvider, previousResults: any[]): Promise<any[]>;
     _doSearch(): void;
     _onSearchTimeout(): void;
-    _onPan(action: any): void;
     _focusChildChanged(provider: AppSearchProvider): void;
     _ensureProviderDisplay(provider: AppSearchProvider): void;
     _clearDisplay(): void;

--- a/packages/gnome-shell/src/ui/slider.d.ts
+++ b/packages/gnome-shell/src/ui/slider.d.ts
@@ -20,44 +20,11 @@ export class Slider extends BarLevel.BarLevel {
     vfunc_repaint(): void;
 
     /**
-     * Handles button press events, initiating dragging.
-     * @param event The Clutter button press event.
-     * @returns The event propagation status.
+     * Moves the value by the given number of scroll steps.
+     * @param nSteps The number of steps, negative to move towards the start.
+     * @returns Whether the value changed.
      */
-    vfunc_button_press_event(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
-
-    /**
-     * Starts dragging the slider.
-     * @param event The Clutter event initiating the drag.
-     * @returns The event propagation status.
-     */
-    startDragging(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
-
-    /**
-     * Ends dragging the slider.
-     * @returns The event propagation status.
-     */
-    _endDragging(): typeof Clutter.EVENT_PROPAGATE;
-
-    /**
-     * Handles button release events.
-     * @returns The event propagation status.
-     */
-    vfunc_button_release_event(): typeof Clutter.EVENT_PROPAGATE;
-
-    /**
-     * Handles touch events for the slider.
-     * @param event The Clutter touch event.
-     * @returns The event propagation status.
-     */
-    vfunc_touch_event(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
-
-    /**
-     * Scrolls the slider.
-     * @param event The Clutter scroll event.
-     * @returns The event propagation status.
-     */
-    scroll(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
+    step(nSteps: number): boolean;
 
     /**
      * Handles the `scroll` signal of the smooth, horizontal scroll controller.
@@ -67,14 +34,6 @@ export class Slider extends BarLevel.BarLevel {
      * @version 51
      */
     _onScroll(controller: Clutter.ScrollController, sprite: Clutter.Sprite, source: Clutter.ScrollSource, dx: number): void;
-
-    /**
-     * Handles motion events during dragging.
-     * @param actor The actor receiving the motion event.
-     * @param event The Clutter motion event.
-     * @returns The event propagation status.
-     */
-    _motionEvent(actor: Clutter.Actor, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
 
     /**
      * Moves the handle a tenth of the range towards the left edge. The Left key

--- a/packages/gnome-shell/src/ui/slider.d.ts
+++ b/packages/gnome-shell/src/ui/slider.d.ts
@@ -60,11 +60,13 @@ export class Slider extends BarLevel.BarLevel {
     scroll(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
 
     /**
-     * Handles scroll events for the slider.
-     * @param event The Clutter scroll event.
-     * @returns The event propagation status.
+     * Handles the `scroll` signal of the smooth, horizontal scroll controller.
+     * The slider adds a second, discrete controller for the vertical axis, and
+     * that one has its own inline handler, so only `dx` arrives here.
+     *
+     * @version 51
      */
-    vfunc_scroll_event(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
+    _onScroll(controller: Clutter.ScrollController, sprite: Clutter.Sprite, source: Clutter.ScrollSource, dx: number): void;
 
     /**
      * Handles motion events during dragging.
@@ -75,11 +77,20 @@ export class Slider extends BarLevel.BarLevel {
     _motionEvent(actor: Clutter.Actor, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
 
     /**
-     * Handles key press events for the slider.
-     * @param event The Clutter key press event.
-     * @returns The event propagation status.
+     * Moves the handle a tenth of the range towards the left edge. The Left key
+     * binding calls it.
+     *
+     * @version 51
      */
-    vfunc_key_press_event(event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE;
+    _moveLeft(): void;
+
+    /**
+     * Moves the handle a tenth of the range towards the right edge. The Right
+     * key binding calls it.
+     *
+     * @version 51
+     */
+    _moveRight(): void;
 
     /**
      * Moves the handle of the slider to a new position based on the given coordinates.

--- a/packages/gnome-shell/src/ui/status/backlight.d.ts
+++ b/packages/gnome-shell/src/ui/status/backlight.d.ts
@@ -1,3 +1,4 @@
+import Clutter from '@girs/clutter-51';
 import St from '@girs/st-51';
 import Gio from '@girs/gio-2.0';
 
@@ -29,6 +30,14 @@ export declare class SliderItem extends PopupMenu.PopupBaseMenuItem {
      * Sets the value of the slider.
      */
     set value(value: number);
+
+    /**
+     * Forwards focus navigation to the slider, so Left and Right reach the
+     * slider's own key bindings.
+     *
+     * @version 51
+     */
+    vfunc_navigate_focus(from: Clutter.Actor | null, direction: St.DirectionType): boolean;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/status/volume.d.ts
+++ b/packages/gnome-shell/src/ui/status/volume.d.ts
@@ -105,12 +105,21 @@ export declare class VolumeIndicator extends SystemIndicator {
     _input: InputStreamSlider;
 
     /**
-     * Handle scroll events for volume adjustment.
-     * @param item The StreamSlider item.
-     * @param event The Clutter scroll event.
-     * @returns Clutter.EVENT_STOP or Clutter.EVENT_PROPAGATE
+     * Handles the indicator's scroll controller. The base class throws
+     * `GObject.NotImplementedError`; subclasses pick the stream to adjust.
+     *
+     * @version 51
      */
-    _handleScrollEvent(item: StreamSlider, event: Clutter.Event): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
+    _onScroll(source: Clutter.ScrollSource, dx: number, dy: number): void;
+
+    /**
+     * Steps the given stream slider and shows its OSD.
+     * @param item The StreamSlider item.
+     * @param delta The scroll delta along the slider's axis.
+     *
+     * @version 51
+     */
+    _handleScroll(item: StreamSlider, delta: number): void;
 }
 
 /**

--- a/packages/gnome-shell/src/ui/switcherPopup.d.ts
+++ b/packages/gnome-shell/src/ui/switcherPopup.d.ts
@@ -23,15 +23,31 @@ export abstract class SwitcherPopup extends St.Widget {
 
     _keyPressHandler(_keysym: any, _action: any): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
 
-    vfunc_key_press_event(keyEvent: Clutter.KeyEvent): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
+    /**
+     * Handles the `key-press` signal of the popup's key controller.
+     *
+     * @version 51
+     */
+    _onKeyPress(controller: Clutter.KeyController): boolean;
 
-    vfunc_key_release_event(keyEvent: Clutter.KeyEvent): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
+    /**
+     * Handles the `modifier-change` signal, which finishes the switch once the
+     * held modifier goes up.
+     *
+     * @version 51
+     */
+    _onModifierChange(controller: Clutter.KeyController): void;
 
     vfunc_button_press_event(): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
 
     _scrollHandler(direction: any): void;
 
-    vfunc_scroll_event(scrollEvent: any /* Clutter.ScrollEvent */): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
+    /**
+     * Handles the `scroll` signal of the popup's scroll controller.
+     *
+     * @version 51
+     */
+    _onScroll(controller: Clutter.ScrollController, sprite: Clutter.Sprite, source: Clutter.ScrollSource, dx: number, dy: number): void;
 
     _itemActivatedHandler(n: number): void;
 

--- a/packages/gnome-shell/src/ui/switcherPopup.d.ts
+++ b/packages/gnome-shell/src/ui/switcherPopup.d.ts
@@ -38,8 +38,6 @@ export abstract class SwitcherPopup extends St.Widget {
      */
     _onModifierChange(controller: Clutter.KeyController): void;
 
-    vfunc_button_press_event(): typeof Clutter.EVENT_PROPAGATE | typeof Clutter.EVENT_STOP;
-
     _scrollHandler(direction: any): void;
 
     /**

--- a/packages/gnome-shell/src/ui/userWidget.d.ts
+++ b/packages/gnome-shell/src/ui/userWidget.d.ts
@@ -2,4 +2,18 @@
 
 import type St from '@girs/st-51';
 
-export class UserWidget extends St.BoxLayout {}
+export class UserWidget extends St.BoxLayout {
+    /**
+     * Hides the avatar and leaves the user name in place.
+     *
+     * @version 51
+     */
+    hideAvatar(): void;
+
+    /**
+     * Shows the avatar again.
+     *
+     * @version 51
+     */
+    showAvatar(): void;
+}


### PR DESCRIPTION
GNOME 51 moved event handling off actor vfuncs and onto `Clutter` actions, gestures and key binding pools. The shell classes stopped overriding `vfunc_*_event` and grew signal handlers instead. Those vfuncs still exist on `Clutter.Actor`, so nothing fails to compile. The declarations just stopped describing the shell, quietly.

Stacked on #145, which is stacked on #144. Merge those first and this diff is only the two commits below.

## First commit, sync with 51

Checked module by module against gnome-shell at tag `51.beta`, for every declared name that changed between `50.4` and `51.beta`.

| module | what changed |
|---|---|
| `appDisplay` | `BaseAppView` / `AppDisplay._onScroll` now takes the `ScrollController::scroll` arguments, and `_onKeyPressEvent` became a binding pool closure |
| `boxpointer` | `_muteKeys` is a `Clutter.KeyController` and `_muteInput` a `Clutter.ClickGesture`, both were `boolean` |
| `calendar` | `vfunc_scroll_event` became `_onScroll` |
| `dialog` | `vfunc_event` became a `KeyController` |
| `layout` | `HotCorner.vfunc_leave_event` is gone |
| `messageList` | `URLHighlighter` motion and leave became a `MotionController`, `Message.vfunc_key_press_event` became `_closeIfAllowed` |
| `messageTray` | `_onNotificationKeyRelease` became a binding pool closure |
| `modalDialog` | `vfunc_captured_event` is gone |
| `search` | new exported `SearchEntry`, with its `activate-new-instance` signal |
| `slider` | scroll and key vfuncs became `_onScroll`, `_moveLeft`, `_moveRight` |
| `status/backlight` | `SliderItem` forwards `vfunc_navigate_focus` to the slider |
| `status/volume` | `_handleScrollEvent` became `_onScroll` plus `_handleScroll` |
| `switcherPopup` | key and scroll vfuncs became `_onKeyPress`, `_onModifierChange`, `_onScroll` |
| `userWidget` | new `showAvatar` and `hideAvatar` |

Everything added carries `@version 51`, per the convention. I applied it to the handlers whose arguments 51 reshaped as well, `appDisplay._onScroll` for one, since the declared contract is the 51 one. Trim those if you read the tag more strictly.

Two additions I left out, because those classes declare no members at all and one more private helper would not help anyone. `ActivitiesButton._toggleAction` in `panel`, declared as `class ActivitiesButton extends Button {}`, and `WindowPreview._onEnter` / `_onLeave` in `windowPreview`, which declares exactly two members.

## Second commit, names 51 did not remove but an earlier release did

Checking those modules turned up a second group, absent at `50.4` as well. They describe an API no supported shell has. Same files, so the same PR, but a separate commit, because it is a different claim and you may want to judge it separately.

`slider` is the worst of them. `startDragging`, `_endDragging`, `_motionEvent`, `scroll` and three vfuncs all went away when the pan gesture landed, and `step(nSteps)`, the method `status/volume` actually calls, was never declared. That one I added. It predates 51, so it carries no `@version` tag.

## What is still wrong after this PR

The same check across the whole package still reports 37 stale member declarations in 12 files. All of them are in modules GNOME 51 did not touch, so they are outside this PR's scope, but they are the same defect.

- `misc/systemActions`: `_loginManager`
- `ui/animation`: `_animationsLoaded`, `_init`, `_loadFile`, `_onDestroy`, `_showFrame`, `_syncAnimationSize`, `_update`
- `ui/closeDialog`: `_onFocusChanged`, `_tracked`
- `ui/components`: `_sessionUpdated`
- `ui/dnd`: `_dragState`, `_eventIsRelease`, `_grabActor`, `_grabDevice`, `_maybeStartDrag`, `_onButtonPress`, `_onTouchEvent`, `_ungrabActor`, `_ungrabDevice`
- `ui/iconGrid`: `_childAdded`, `_childRemoved`
- `ui/messageList`: `_closeButton`, `_getIcon`, `_onUpdated`, `_secondaryBin`
- `ui/status/accessibility`: `_buildItemExtended`
- `ui/status/brightness`: `_changeSlider`, `_proxy`, `_sliderChanged`, `_sliderChangedId`
- `ui/status/network`: `_closeConnectivityCheck`, `_flushConnectivityQueue`, `_portalHelperDone`
- `ui/status/remoteAccess`: `vfunc_event`
- `ui/status/thunderbolt`: `_ensureSource`, `_source`

`ui/animation` is the striking one. `Spinner` uses a `constructor` now, and the `Animation` base class the declaration describes is not in `js/ui/animation.js` at all any more.

There is a stale export too. `search.d.ts` exports `MaxWidthBox`, which upstream has kept module-private since at least 50.4. Removing an export breaks consumers, so I left it alone.

## The part worth automating

I found all of this with a throwaway script. Parse the declared members out of each `.d.ts`, parse the defined names out of the matching `js/` file at a given tag, print the difference. It found the 51 drift and the older drift in one run, and it is the only reason this PR is a list rather than a guess.

It could live in the repo as `scripts/check-shell-api.mjs`, run against a shallow `git clone --depth 1 --branch <tag>` of gnome-shell, so each cycle starts from a diff instead of from whatever the compiler happens to notice. It cannot be a required check until the 37 above are dealt with, but it can run and report. Say the word and I will send it.

One caveat, so nobody over-trusts it. It matches names, not shapes. It cannot see a method whose signature changed, and it has false positives around static class fields. `_mediaSource` in `messageList` was one, a `static _mediaSource = …`, which I checked and kept. Every removal in this PR I verified by reading the upstream source, not by trusting the script.

## Validation

`build:types`, `prettier:check`, `validate:types`, `build:example` and `validate:example` all pass locally.
